### PR TITLE
Update SPDX License ID in Solidity files

### DIFF
--- a/contracts/src/CrossChainApplications/ERC20Bridge/BridgeToken.sol
+++ b/contracts/src/CrossChainApplications/ERC20Bridge/BridgeToken.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/CrossChainApplications/ERC20Bridge/ERC20Bridge.sol
+++ b/contracts/src/CrossChainApplications/ERC20Bridge/ERC20Bridge.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/CrossChainApplications/ERC20Bridge/IERC20Bridge.sol
+++ b/contracts/src/CrossChainApplications/ERC20Bridge/IERC20Bridge.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/CrossChainApplications/ERC20Bridge/tests/ERC20BridgeTests.t.sol
+++ b/contracts/src/CrossChainApplications/ERC20Bridge/tests/ERC20BridgeTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/CrossChainApplications/ExampleMessenger/ExampleCrossChainMessenger.sol
+++ b/contracts/src/CrossChainApplications/ExampleMessenger/ExampleCrossChainMessenger.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/CrossChainApplications/VerifiedBlockHash/BlockHashPublisher.sol
+++ b/contracts/src/CrossChainApplications/VerifiedBlockHash/BlockHashPublisher.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/CrossChainApplications/VerifiedBlockHash/BlockHashReceiver.sol
+++ b/contracts/src/CrossChainApplications/VerifiedBlockHash/BlockHashReceiver.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Mocks/ExampleERC20.sol
+++ b/contracts/src/Mocks/ExampleERC20.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Mocks/UnitTestMockERC20.sol
+++ b/contracts/src/Mocks/UnitTestMockERC20.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/ITeleporterMessenger.sol
+++ b/contracts/src/Teleporter/ITeleporterMessenger.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/ITeleporterReceiver.sol
+++ b/contracts/src/Teleporter/ITeleporterReceiver.sol
@@ -1,7 +1,7 @@
 // (c) 2022-2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/ReceiptQueue.sol
+++ b/contracts/src/Teleporter/ReceiptQueue.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/ReentrancyGuards.sol
+++ b/contracts/src/Teleporter/ReentrancyGuards.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/SafeERC20TransferFrom.sol
+++ b/contracts/src/Teleporter/SafeERC20TransferFrom.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/TeleporterMessenger.sol
+++ b/contracts/src/Teleporter/TeleporterMessenger.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/AddFeeAmountTests.t.sol
+++ b/contracts/src/Teleporter/tests/AddFeeAmountTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/CheckAllowedRelayerTests.t.sol
+++ b/contracts/src/Teleporter/tests/CheckAllowedRelayerTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/GetFeeInfoTests.t.sol
+++ b/contracts/src/Teleporter/tests/GetFeeInfoTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/GetMessageHashTests.t.sol
+++ b/contracts/src/Teleporter/tests/GetMessageHashTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/GetNextMessageIdTests.t.sol
+++ b/contracts/src/Teleporter/tests/GetNextMessageIdTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/GetOutstandingReceiptsToSendTests.t.sol
+++ b/contracts/src/Teleporter/tests/GetOutstandingReceiptsToSendTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/GetRelayerRewardAddressTests.t.sol
+++ b/contracts/src/Teleporter/tests/GetRelayerRewardAddressTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/HandleInitialMessageExecutionTests.t.sol
+++ b/contracts/src/Teleporter/tests/HandleInitialMessageExecutionTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/MarkReceiptTests.t.sol
+++ b/contracts/src/Teleporter/tests/MarkReceiptTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/MessageReceivedTests.t.sol
+++ b/contracts/src/Teleporter/tests/MessageReceivedTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/ReceiptsQueueTests.t.sol
+++ b/contracts/src/Teleporter/tests/ReceiptsQueueTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/ReceiveCrossChainMessageTests.t.sol
+++ b/contracts/src/Teleporter/tests/ReceiveCrossChainMessageTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/RedeemRelayerRewardsTests.t.sol
+++ b/contracts/src/Teleporter/tests/RedeemRelayerRewardsTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/ReentrancyGuardsTests.t.sol
+++ b/contracts/src/Teleporter/tests/ReentrancyGuardsTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/RetryMessageExecutionTests.t.sol
+++ b/contracts/src/Teleporter/tests/RetryMessageExecutionTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/RetryReceiptTests.t.sol
+++ b/contracts/src/Teleporter/tests/RetryReceiptTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/RetrySendCrossChainMessageTests.t.sol
+++ b/contracts/src/Teleporter/tests/RetrySendCrossChainMessageTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/SendCrossChainMessageTests.t.sol
+++ b/contracts/src/Teleporter/tests/SendCrossChainMessageTests.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 

--- a/contracts/src/Teleporter/tests/TeleporterMessengerTest.t.sol
+++ b/contracts/src/Teleporter/tests/TeleporterMessengerTest.t.sol
@@ -1,7 +1,7 @@
 // (c) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Ecosystem
 
 pragma solidity 0.8.18;
 


### PR DESCRIPTION
## Why this should be merged

Aligns the SDPX License ID to the LICENSE file in the repo. Note that "Ecosystem" is not an official SPDX License ID on this list [here](https://spdx.org/licenses/), but according to the [documentation here](https://docs.soliditylang.org/en/v0.8.21/layout-of-source-files.html#spdx-license-identifier), "The compiler does not validate that the license is part of the list allowed by SPDX, but it does include the supplied string in the bytecode metadata.".

Thank you to @minghinmatthewlam for calling this out.

## How this was tested

CI/CD

## How is this documented

N/A