### PR TITLE
Fixing solhint lint workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
 
             - name: Install solhint
               run: |
-                  npm install solhint@3.4.1 -g
+                  npm install solhint -g
                   solhint --version
 
             - name: Run Lint

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,10 +17,10 @@ jobs:
 
             - name: Install solhint
               run: |
-                  npm install solhint -g
+                  npm install solhint
                   solhint --version
 
             - name: Run Lint
               run: |
                   cd contracts/src
-                  solhint '**/*.sol' --config ./.solhint.json --ignore-path ./.solhintignore --max-warnings 0
+                  npx solhint '**/*.sol' --config ./.solhint.json --ignore-path ./.solhintignore --max-warnings 0

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Install solhint
               run: |
                   npm install solhint
-                  solhint --version
+                  npx solhint --version
 
             - name: Run Lint
               run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,6 +20,8 @@ jobs:
                   npm install solhint
                   npx solhint --version
 
+            # "solhint **/*.sol" runs differently than "solhint '**/*.sol'", where the latter checks sol files
+            # in subdirectories. The former only checks sol files in the current directory and directories one level down.
             - name: Run Lint
               run: |
                   cd contracts/src

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,10 +17,10 @@ jobs:
 
             - name: Install solhint
               run: |
-                  npm install solhint
-                  npx solhint --version
+                  npm install solhint -g
+                  solhint --version
 
             - name: Run Lint
               run: |
                   cd contracts/src
-                  npx solhint **/*.sol --config ./.solhint.json --ignore-path ./.solhintignore --max-warnings 0
+                  solhint **/*.sol --config ./.solhint.json --ignore-path ./.solhintignore --max-warnings 0

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,4 +23,4 @@ jobs:
             - name: Run Lint
               run: |
                   cd contracts/src
-                  solhint **/*.sol --config ./.solhint.json --ignore-path ./.solhintignore --max-warnings 0
+                  solhint '**/*.sol' --config ./.solhint.json --ignore-path ./.solhintignore --max-warnings 0

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
 
             - name: Install solhint
               run: |
-                  npm install solhint -g
+                  npm install solhint@3.4.1 -g
                   solhint --version
 
             - name: Run Lint

--- a/contracts/src/.solhint.json
+++ b/contracts/src/.solhint.json
@@ -16,7 +16,17 @@
                 "strict": true
             }
         ],
+        "reason-string": ["off"],
         "ordering": "warn",
-        "no-global-import": "off"
+        "immutable-vars-naming": [
+            "warn",
+            {
+                "immutablesAsConstants": false
+            }
+        ],
+        "func-named-parameters": ["warn", 5],
+        "custom-errors": "off",
+        "no-global-import": "off",
+        "one-contract-per-file": "off"
     }
 }

--- a/contracts/src/.solhint.json
+++ b/contracts/src/.solhint.json
@@ -1,10 +1,7 @@
 {
     "extends": "solhint:recommended",
     "rules": {
-        "compiler-version": [
-            "error",
-            "0.8.18"
-        ],
+        "compiler-version": ["error", "0.8.18"],
         "no-unused-vars": "warn",
         "func-visibility": [
             "warn",
@@ -12,31 +9,14 @@
                 "ignoreConstructors": true
             }
         ],
-        "max-line-length": [
-            "off"
-        ],
+        "max-line-length": ["off"],
         "private-vars-leading-underscore": [
             "warn",
             {
                 "strict": true
             }
         ],
-        "reason-string": [
-            "off"
-        ],
         "ordering": "warn",
-        "immutable-vars-naming": [
-            "warn",
-            {
-                "immutablesAsConstants": false
-            }
-        ],
-        "func-named-parameters": [
-            "warn",
-            5
-        ],
-        "custom-errors": "off",
-        "no-global-import": "off",
-        "one-contract-per-file": "off"
+        "no-global-import": "off"
     }
 }

--- a/contracts/src/CrossChainApplications/ERC20Bridge/ERC20Bridge.sol
+++ b/contracts/src/CrossChainApplications/ERC20Bridge/ERC20Bridge.sol
@@ -383,6 +383,7 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
     ) public pure returns (bytes memory) {
         // ABI encode the Transfer action and corresponding parameters for the transferBridgeToken
         // call to to be decoded and executed on the destination.
+        // solhint-disable-next-line func-named-parameters
         bytes memory paramsData = abi.encode(
             destinationChainID,
             destinationBridgeAddress,


### PR DESCRIPTION
## Why this should be merged
Fixes #11 , where workflows should now fail on solhint errors
Adds a solhint disable for a false positive solhint error on `abi.encode`

## How this works
`solhint **/*.sol` is apparently different from `solhint '**/*'.sol` where the latter will sol files in nested directories under `contracts/src`, whereas the former only looks at sol files in `contracts/src` directory and one directory down.

## How this was tested
ci

## How is this documented
added comment in worfklow