### PR TITLE
Fix forge create argument order

### DIFF
--- a/scripts/local/integration-tests/basic_send_receive.sh
+++ b/scripts/local/integration-tests/basic_send_receive.sh
@@ -30,10 +30,10 @@ set -e # Stop on first error
 
 # Deploy a test ERC20 to be used in the E2E test.
 cd contracts
-erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $subnet_a_url)
+erc20_deploy_result=$(forge create --private-key $user_private_key --rpc-url $subnet_a_url src/Mocks/ExampleERC20.sol:ExampleERC20)
 erc20_contract_address_a=$(parseContractAddress "$erc20_deploy_result")
 echo "Test ERC20 contract deployed to $erc20_contract_address_a on subnet A"
-erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $subnet_b_url)
+erc20_deploy_result=$(forge create --private-key $user_private_key --rpc-url $subnet_b_url src/Mocks/ExampleERC20.sol:ExampleERC20)
 erc20_contract_address_b=$(parseContractAddress "$erc20_deploy_result")
 echo "Test ERC20 contract deployed to $erc20_contract_address_b on subnet B"
 

--- a/scripts/local/integration-tests/erc20_bridge_multihop.sh
+++ b/scripts/local/integration-tests/erc20_bridge_multihop.sh
@@ -35,7 +35,7 @@ set -e # Stop on first error
 
 # Deploy an ERC20 to subnet A.
 cd contracts
-native_erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $subnet_a_url)
+native_erc20_deploy_result=$(forge create --private-key $user_private_key --rpc-url $subnet_a_url src/Mocks/ExampleERC20.sol:ExampleERC20)
 native_erc20_contract_address=$(parseContractAddress "$native_erc20_deploy_result")
 echo "Test ERC20 contract deployed to $native_erc20_contract_address on Subnet A"
 

--- a/scripts/local/integration-tests/example_messenger.sh
+++ b/scripts/local/integration-tests/example_messenger.sh
@@ -25,7 +25,7 @@ set -e # Stop on first error
 
 # Deploy a test ERC20 on subnet A.
 cd contracts
-erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $subnet_a_url)
+erc20_deploy_result=$(forge create --private-key $user_private_key --rpc-url $subnet_a_url src/Mocks/ExampleERC20.sol:ExampleERC20)
 erc20_contract_address=$(parseContractAddress "$erc20_deploy_result")
 echo "Test ERC20 contract deployed to $erc20_contract_address on Subnet A"
 

--- a/scripts/local/integration-tests/retry_receipts.sh
+++ b/scripts/local/integration-tests/retry_receipts.sh
@@ -32,10 +32,10 @@ set -e # Stop on first error
 
 # Deploy a test ERC20 to be used in the E2E test.
 cd contracts
-erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $subnet_a_url)
+erc20_deploy_result=$(forge create --private-key $user_private_key --rpc-url $subnet_a_url src/Mocks/ExampleERC20.sol:ExampleERC20)
 erc20_contract_address_a=$(parseContractAddress "$erc20_deploy_result")
 echo "Test ERC20 contract deployed to $erc20_contract_address_a on subnet A"
-erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $subnet_b_url)
+erc20_deploy_result=$(forge create --private-key $user_private_key --rpc-url $subnet_b_url src/Mocks/ExampleERC20.sol:ExampleERC20)
 erc20_contract_address_b=$(parseContractAddress "$erc20_deploy_result")
 echo "Test ERC20 contract deployed to $erc20_contract_address_b on subnet B"
 


### PR DESCRIPTION
## Why this should be merged

[Forge create](https://book.getfoundry.sh/reference/forge/forge-create) uses the env variable `$user_private_key`. Before this change the order was:

``` bash
forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $subnet_a_url 
```

If the env variable `$user_private_key` is not set, foundry thinks `src/Mocks/ExampleERC20.sol:ExampleERC20` is the argument for the `--private-key` flag and the error message was stating that no contract was supplied. This is misleading since the real problem is, that no private key is supplied.

## How this works

Change the order of the argument

``` bash
forge create --private-key $user_private_key --rpc-url $subnet_a_url src/Mocks/ExampleERC20.sol:ExampleERC20 
```

This way of no private key is supplied, the error message states that.

## How this was tested

Ran the scripts

## How is this documented

No documentation necessary