### PR TITLE
Use custom errors for reverts

### DIFF
--- a/contracts/src/.solhint.json
+++ b/contracts/src/.solhint.json
@@ -25,7 +25,6 @@
             }
         ],
         "func-named-parameters": ["warn", 5],
-        "custom-errors": "off",
         "no-global-import": "off",
         "one-contract-per-file": "off"
     }

--- a/contracts/src/CrossChainApplications/ERC20Bridge/BridgeToken.sol
+++ b/contracts/src/CrossChainApplications/ERC20Bridge/BridgeToken.sol
@@ -19,6 +19,12 @@ contract BridgeToken is ERC20Burnable {
 
     uint8 private immutable _decimals;
 
+    // Errors
+    error Unauthorized();
+    error InvalidChainID();
+    error InvalidSourceBridgeAddress();
+    error InvalidSourceAsset();
+
     /**
      * @dev Initializes a BridgeToken instance.
      */
@@ -30,9 +36,15 @@ contract BridgeToken is ERC20Burnable {
         string memory tokenSymbol,
         uint8 tokenDecimals
     ) ERC20(tokenName, tokenSymbol) {
-        require(sourceChainID != bytes32(0), "Invalid source chain ID.");
-        require(sourceBridge != address(0), "Invalid source bridge address.");
-        require(sourceAsset != address(0), "Invalid source asset.");
+        if (sourceChainID == bytes32(0)) {
+            revert InvalidChainID();
+        }
+        if (sourceBridge == address(0)) {
+            revert InvalidSourceBridgeAddress();
+        }
+        if (sourceAsset == address(0)) {
+            revert InvalidSourceAsset();
+        }
         bridgeContract = msg.sender;
         nativeChainID = sourceChainID;
         nativeBridge = sourceBridge;
@@ -44,7 +56,9 @@ contract BridgeToken is ERC20Burnable {
      * @dev Mints tokens to `account` if called by original `bridgeContract`.
      */
     function mint(address account, uint256 amount) public {
-        require(msg.sender == bridgeContract, "Unauthorized.");
+        if (msg.sender != bridgeContract) {
+            revert Unauthorized();
+        }
         _mint(account, amount);
     }
 

--- a/contracts/src/CrossChainApplications/ERC20Bridge/ERC20Bridge.sol
+++ b/contracts/src/CrossChainApplications/ERC20Bridge/ERC20Bridge.sol
@@ -73,15 +73,29 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
     uint256 public constant MINT_BRIDGE_TOKENS_REQUIRED_GAS = 200_000;
     uint256 public constant TRANSFER_BRIDGE_TOKENS_REQUIRED_GAS = 300_000;
 
+    // Errors
+    error InvalidTeleporterMessengerAddress();
+    error BridgeTokenWithinSameChain();
+    error InvalidRecipientAddress();
+    error InvalidDestinationBridgeAddress();
+    error FeeAmountsMoreThanTotal(uint256 totalAmount, uint256 feeAmount);
+    error InvalidBridgeTokenAddress();
+    error FeeAmountMoreThanAdjustedAmount(uint256 adjustedAmount, uint256 feeAmount);
+    error Unauthorized();
+    error InvalidAction();
+    error BridgeTokenAlreadyExists(address bridgeTokenAddress);
+    error InsufficientWrappedTokenBalance(uint256 currentBalance, uint256 requestAmount);
+    error WrappedTokenDoesNotExist(address nativeTokenAddress);
+
     /**
      * @dev Initializes the Teleporter messenger used for sending and receiving messages,
      * and initializes the current chain ID.
      */
     constructor(address teleporterMessengerAddress) {
-        require(
-            teleporterMessengerAddress != address(0),
-            "Invalid teleporter messenger address"
-        );
+        if (teleporterMessengerAddress == address(0)) {
+            revert InvalidTeleporterMessengerAddress();
+        }
+
         teleporterMessenger = ITeleporterMessenger(teleporterMessengerAddress);
         currentChainID = WarpMessenger(WARP_PRECOMPILE_ADDRESS)
             .getBlockchainID();
@@ -106,21 +120,18 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         uint256 secondaryFeeAmount
     ) external nonReentrant {
         // Bridging tokens within a single chain is not allowed.
-        require(
-            destinationChainID != currentChainID,
-            "Cannot bridge token within same chain."
-        );
+        if (destinationChainID == currentChainID) {
+            revert BridgeTokenWithinSameChain();
+        }
 
         // Neither the recipient nor the destination bridge can be the zero address.
-        require(
-            recipient != address(0),
-            "Recipient address cannot be zero address."
-        );
+        if (recipient == address(0)) {
+            revert InvalidRecipientAddress();
+        }
 
-        require(
-            destinationBridgeAddress != address(0),
-            "Destination bridge address cannot be zero address."
-        );
+        if (destinationBridgeAddress == address(0)) {
+            revert InvalidDestinationBridgeAddress();
+        }
 
         // If the token to be bridged is an existing wrapped token of this bridge,
         // then handle it as an "unwrap" by burning the tokens, and sending a message
@@ -132,10 +143,9 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
             // In the wrapped token case, we know that the bridgeToken to be burned
             // is not a "fee/burn on transfer" token, since it was deployed by this
             // contract itself.
-            require(
-                totalAmount > primaryFeeAmount + secondaryFeeAmount,
-                "Fee amounts more than total."
-            );
+            if (totalAmount <= primaryFeeAmount + secondaryFeeAmount) {
+                revert FeeAmountsMoreThanTotal(totalAmount, primaryFeeAmount + secondaryFeeAmount);
+            }
 
             return
                 _processWrappedTokenTransfer(
@@ -152,12 +162,11 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         }
 
         // Otherwise, this is a token "native" to this chain.
-        require(
-            submittedBridgeTokenCreations[destinationChainID][
-                destinationBridgeAddress
-            ][tokenContractAddress],
-            "Bridge token has not been previously submitted for creation."
-        );
+        if (!submittedBridgeTokenCreations[destinationChainID][
+            destinationBridgeAddress
+        ][tokenContractAddress]) {
+            revert InvalidBridgeTokenAddress();
+        }
 
         // Lock tokens in this bridge instance. Supports "fee/burn on transfer" ERC20 token
         // implementations by only bridging the actual balance increase reflected by the call
@@ -170,10 +179,9 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         // Ensure that the adjusted amount is greater than the fee to be paid.
         // The secondary fee amount is not used in this case (and can assumed to be 0) since bridging
         // a native token to another chain only ever involves a single cross-chain message.
-        require(
-            adjustedAmount > primaryFeeAmount,
-            "Fee amount more than adjusted transfer amount."
-        );
+        if (adjustedAmount <= primaryFeeAmount) {
+            revert FeeAmountMoreThanAdjustedAmount(adjustedAmount, primaryFeeAmount);
+        }
 
         return
             _processNativeTokenTransfer({
@@ -203,10 +211,9 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         address messageFeeAsset,
         uint256 messageFeeAmount
     ) external nonReentrant {
-        require(
-            destinationBridgeAddress != address(0),
-            "Destination bridge address cannot be zero address."
-        );
+        if (destinationBridgeAddress == address(0)) {
+            revert InvalidDestinationBridgeAddress();
+        }
 
         // For non-zero fee amounts, transfer the fee into the control of this contract first, and then
         // allow the Teleporter contract to spend it.
@@ -268,7 +275,9 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         bytes calldata message
     ) external {
         // Only allow the Teleporter messenger to deliver messages.
-        require(msg.sender == address(teleporterMessenger), "Unauthorized.");
+        if (msg.sender != address(teleporterMessenger)) {
+            revert Unauthorized();
+        }
 
         // Decode the payload to recover the action and corresponding function parameters
         (BridgeAction action, bytes memory actionData) = abi.decode(
@@ -328,7 +337,7 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
                 secondaryFeeAmount: secondaryFeeAmount
             });
         } else {
-            revert("Invalid action.");
+            revert InvalidAction();
         }
     }
 
@@ -409,12 +418,15 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         uint8 nativeDecimals
     ) private {
         // Check that the bridge token doesn't already exist.
-        require(
-            nativeToWrappedTokens[nativeChainID][nativeBridgeAddress][
-                nativeContractAddress
-            ] == address(0),
-            "Bridge token already exists."
-        );
+        if (nativeToWrappedTokens[nativeChainID][nativeBridgeAddress][
+            nativeContractAddress
+        ] != address(0)) {
+            revert BridgeTokenAlreadyExists(
+                nativeToWrappedTokens[nativeChainID][nativeBridgeAddress][
+                    nativeContractAddress
+                ]
+            );
+        }
 
         address bridgeTokenAddress = address(
             new BridgeToken({
@@ -453,13 +465,14 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         uint256 amount
     ) private nonReentrant {
         // Only allow the Teleporter messenger to deliver messages.
-        require(msg.sender == address(teleporterMessenger), "Unauthorized.");
+        if (msg.sender != address(teleporterMessenger)) {
+            revert Unauthorized();
+        }
 
         // The recipient cannot be the zero address.
-        require(
-            recipient != address(0),
-            "Recipient address cannot be zero address."
-        );
+        if (recipient == address(0)) {
+            revert InvalidRecipientAddress();
+        }
 
         // Check that a bridge token exists for this native asset.
         // If not, one needs to be created by the delivery of a "createBridgeToken" message first
@@ -468,10 +481,9 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         address bridgeTokenAddress = nativeToWrappedTokens[nativeChainID][
             nativeBridgeAddress
         ][nativeContractAddress];
-        require(
-            bridgeTokenAddress != address(0),
-            "Bridge token does not yet exist."
-        );
+        if (bridgeTokenAddress == address(0)) {
+            revert InvalidBridgeTokenAddress();
+        }
 
         // Mint the wrapped tokens.
         BridgeToken(bridgeTokenAddress).mint(recipient, amount);
@@ -493,27 +505,27 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         uint256 secondaryFeeAmount
     ) private nonReentrant {
         // Only allow the teleporter messenger to deliver messages.
-        require(msg.sender == address(teleporterMessenger), "Unauthorized.");
+        if (msg.sender != address(teleporterMessenger)) {
+            revert Unauthorized();
+        }
 
         // Neither the recipient nor the destination bridge can be the zero address.
-        require(
-            recipient != address(0),
-            "Recipient address cannot be zero address."
-        );
+        if (recipient == address(0)) {
+            revert InvalidRecipientAddress();
+        }
 
-        require(
-            destinationBridgeAddress != address(0),
-            "Destination bridge address cannot be zero address."
-        );
+        if (destinationBridgeAddress == address(0)) {
+            revert InvalidDestinationBridgeAddress();
+        }
 
         // Check that the bridge returning the tokens has sufficient balance to do so.
         uint256 currentBalance = bridgedBalances[sourceChainID][
             sourceBridgeAddress
         ][nativeContractAddress];
-        require(
-            currentBalance >= totalAmount,
-            "Insufficient wrapped token balance."
-        );
+        if (currentBalance < totalAmount) {
+            revert InsufficientWrappedTokenBalance(currentBalance, totalAmount);
+        }
+
         bridgedBalances[sourceChainID][sourceBridgeAddress][
             nativeContractAddress
         ] = currentBalance - totalAmount;
@@ -521,10 +533,9 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         // If the destination chain ID and bridge is this bridge instance, then release the tokens back to the recipient.
         // In this case, since there is no secondary Teleporter message, the secondary fee amount is not used.
         if (destinationChainID == currentChainID) {
-            require(
-                destinationBridgeAddress == address(this),
-                "Destination bridge address must be this bridge instance."
-            );
+            if (destinationBridgeAddress != address(this)) {
+                revert InvalidDestinationBridgeAddress();
+            }
 
             // Transfer tokens to the recipient.
             // We don't need have a special case for handling "fee/burn on transfer" ERC20 token implementations
@@ -570,18 +581,16 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         uint256 feeAmount
     ) private {
         // Do not allow nested bridging of wrapped tokens.
-        require(
-            !wrappedTokenContracts[nativeContractAddress],
-            "Cannot bridge wrapped token."
-        );
+        if (wrappedTokenContracts[nativeContractAddress]) {
+            revert WrappedTokenDoesNotExist(nativeContractAddress);
+        }
 
         // Bridging tokens within a single chain is not allowed.
         // This function is called by bridgeTokens and transferBridgeTokens which both already make this check,
         // so this check is redundant but left in for clarity.
-        require(
-            destinationChainID != currentChainID,
-            "Cannot bridge token within same chain."
-        );
+        if (destinationChainID == currentChainID) {
+            revert BridgeTokenWithinSameChain();
+        }
 
         // Allow the Teleporter messenger to spend the fee amount.
         if (feeAmount > 0) {
@@ -675,11 +684,9 @@ contract ERC20Bridge is IERC20Bridge, ITeleporterReceiver, ReentrancyGuard {
         bytes32 nativeChainID = bridgeToken.nativeChainID();
         address nativeBridgeAddress = bridgeToken.nativeBridge();
         if (wrappedTransferInfo.destinationChainID == nativeChainID) {
-            require(
-                wrappedTransferInfo.destinationBridgeAddress ==
-                    nativeBridgeAddress,
-                "Invalid destination bridge address for native chain."
-            );
+            if (wrappedTransferInfo.destinationBridgeAddress != nativeBridgeAddress) {
+                revert InvalidDestinationBridgeAddress();
+            }
         }
 
         // Send a message to the native chain and bridge of the wrapped asset that was burned.

--- a/contracts/src/CrossChainApplications/ERC20Bridge/tests/ERC20BridgeTests.t.sol
+++ b/contracts/src/CrossChainApplications/ERC20Bridge/tests/ERC20BridgeTests.t.sol
@@ -71,7 +71,7 @@ contract ERC20BridgeTest is Test {
     }
 
     function testSameChainID() public {
-        vm.expectRevert("Cannot bridge token within same chain.");
+        vm.expectRevert(ERC20Bridge.BridgeTokenWithinSameChain.selector);
         erc20Bridge.bridgeTokens({
             destinationChainID: _MOCK_BLOCKCHAIN_ID,
             destinationBridgeAddress: _DEFAULT_OTHER_BRIDGE_ADDRESS,
@@ -90,7 +90,9 @@ contract ERC20BridgeTest is Test {
             _DEFAULT_OTHER_BRIDGE_ADDRESS,
             address(mockERC20)
         );
-        vm.expectRevert("Fee amount more than adjusted transfer amount.");
+        vm.expectRevert(abi.encodePacked(
+            ERC20Bridge.FeeAmountMoreThanAdjustedAmount.selector,
+            uint256(130), uint256(130)));
         erc20Bridge.bridgeTokens({
             destinationChainID: _DEFAULT_OTHER_CHAIN_ID,
             destinationBridgeAddress: _DEFAULT_OTHER_BRIDGE_ADDRESS,
@@ -113,7 +115,9 @@ contract ERC20BridgeTest is Test {
             contractNonce: 1
         });
 
-        vm.expectRevert("Fee amounts more than total.");
+        vm.expectRevert(abi.encodePacked(
+            ERC20Bridge.FeeAmountsMoreThanTotal.selector,
+            uint256(130), uint256(130)));
         erc20Bridge.bridgeTokens({
             destinationChainID: _DEFAULT_OTHER_CHAIN_ID,
             destinationBridgeAddress: _DEFAULT_OTHER_BRIDGE_ADDRESS,
@@ -490,7 +494,9 @@ contract ERC20BridgeTest is Test {
             address(mockERC20)
         );
 
-        vm.expectRevert("Fee amount more than adjusted transfer amount.");
+        vm.expectRevert(abi.encodePacked(
+            ERC20Bridge.FeeAmountMoreThanAdjustedAmount.selector,
+            uint256(totalAmount - tokenFeeOnTransferAmount), uint256(bridgeFeeAmount)));
         erc20Bridge.bridgeTokens({
             destinationChainID: _DEFAULT_OTHER_CHAIN_ID,
             destinationBridgeAddress: _DEFAULT_OTHER_BRIDGE_ADDRESS,

--- a/contracts/src/CrossChainApplications/ExampleMessenger/ExampleCrossChainMessenger.sol
+++ b/contracts/src/CrossChainApplications/ExampleMessenger/ExampleCrossChainMessenger.sol
@@ -49,6 +49,9 @@ contract ExampleCrossChainMessenger is ITeleporterReceiver, ReentrancyGuard {
         string message
     );
 
+    // Errors
+    error Unauthorized();
+
     constructor(address teleporterMessengerAddress) {
         teleporterMessenger = ITeleporterMessenger(teleporterMessengerAddress);
     }
@@ -64,7 +67,9 @@ contract ExampleCrossChainMessenger is ITeleporterReceiver, ReentrancyGuard {
         bytes calldata message
     ) external {
         // Only the Teleporter receiver can deliver a message.
-        require(msg.sender == address(teleporterMessenger), "Unauthorized.");
+        if (msg.sender != address(teleporterMessenger)) {
+            revert Unauthorized();
+        }
 
         // Store the message.
         string memory messageString = abi.decode(message, (string));

--- a/contracts/src/CrossChainApplications/VerifiedBlockHash/BlockHashReceiver.sol
+++ b/contracts/src/CrossChainApplications/VerifiedBlockHash/BlockHashReceiver.sol
@@ -32,6 +32,11 @@ contract BlockHashReceiver is ITeleporterReceiver {
         bytes32 blockHash
     );
 
+    // Errors
+    error Unauthorized();
+    error InvalidSourceChainID();
+    error InvalidSourceChainPublisher();
+
     constructor(
         address teleporterMessengerAddress,
         bytes32 publisherChainID,
@@ -58,15 +63,17 @@ contract BlockHashReceiver is ITeleporterReceiver {
         address originSenderAddress,
         bytes calldata message
     ) external {
-        require(
-            msg.sender == address(teleporterMessenger),
-            "Unauthorized caller."
-        );
-        require(originChainID == sourceChainID, "Invalid source chain ID.");
-        require(
-            originSenderAddress == sourcePublisherContractAddress,
-            "Unauthorized source chain publisher"
-        );
+        if (msg.sender != address(teleporterMessenger)) {
+            revert Unauthorized();
+        }
+
+        if (originChainID != sourceChainID) {
+            revert InvalidSourceChainID();
+        }
+
+        if (originSenderAddress != sourcePublisherContractAddress) {
+            revert InvalidSourceChainPublisher();
+        }
 
         (uint256 blockHeight, bytes32 blockHash) = abi.decode(
             message,

--- a/contracts/src/Mocks/ExampleERC20.sol
+++ b/contracts/src/Mocks/ExampleERC20.sol
@@ -11,15 +11,18 @@ contract ExampleERC20 is ERC20Burnable {
     string private constant _TOKEN_NAME = "Mock Token";
     string private constant _TOKEN_SYMBOL = "EXMP";
 
+    // Errors
+    error MaxAmountExceeded(uint256 maxAmount, uint256 mintAmount);
+
     constructor() ERC20(_TOKEN_NAME, _TOKEN_SYMBOL) {
         _mint(msg.sender, 10_000_000_000_000_000_000_000_000_000);
     }
 
     function mint(uint256 amount) public {
-        require(
-            amount <= 10_000_000_000_000_000_000,
-            "Can only mint 10 at a time."
-        );
+        if (amount > 10_000_000_000_000_000) {
+            revert MaxAmountExceeded(10_000_000_000_000_000, amount);
+        }
+
         _mint(msg.sender, amount);
     }
 }

--- a/contracts/src/Teleporter/ReceiptQueue.sol
+++ b/contracts/src/Teleporter/ReceiptQueue.sol
@@ -33,6 +33,10 @@ contract ReceiptQueue {
         address indexed relayerRewardAddress
     );
 
+    // Errors
+    error Unauthorized();
+    error EmptyQueue();
+
     constructor() {
         owner = msg.sender;
     }
@@ -45,7 +49,10 @@ contract ReceiptQueue {
      * - `msg.sender` must be the owner.
      */
     function enqueue(TeleporterMessageReceipt calldata receipt) external {
-        require(msg.sender == owner, "Unauthorized.");
+        if (msg.sender != owner) {
+            revert Unauthorized();
+        }
+
         queue[last++] = receipt;
 
         emit Enqueue(receipt.receivedMessageID, receipt.relayerRewardAddress);
@@ -63,9 +70,15 @@ contract ReceiptQueue {
         external
         returns (TeleporterMessageReceipt memory result)
     {
-        require(msg.sender == owner, "Unauthorized.");
+        if (msg.sender != owner) {
+            revert Unauthorized();
+        }
+
         uint256 first_ = first;
-        require(last > first_, "Empty queue."); // non-empty queue
+
+        if (last == first_) {
+            revert EmptyQueue(); // empty queue
+        }
 
         result = queue[first_];
 

--- a/contracts/src/Teleporter/ReentrancyGuards.sol
+++ b/contracts/src/Teleporter/ReentrancyGuards.sol
@@ -21,11 +21,17 @@ abstract contract ReentrancyGuards {
     uint256 internal _sendEntered;
     uint256 internal _receiveEntered;
 
+    // Errors
+    error SenderReentrancy();
+    error ReceiverReentrancy();
+
     // senderNonReentrant modifier makes sure we can not reenter between sender calls.
     // This modifier should be used for messenger sender functions that have external calls and do not want to allow
     // recursive calls with other sender functions.
     modifier senderNonReentrant() {
-        require(_sendEntered == _NOT_ENTERED, "Sender reentrancy");
+        if (_sendEntered != _NOT_ENTERED) {
+            revert SenderReentrancy();
+        }
         _sendEntered = _ENTERED;
         _;
         _sendEntered = _NOT_ENTERED;
@@ -35,7 +41,9 @@ abstract contract ReentrancyGuards {
     // This modifier should be used for messenger receiver functions that have external calls and do not want to allow
     // recursive calls with other receiver functions.
     modifier receiverNonReentrant() {
-        require(_receiveEntered == _NOT_ENTERED, "Receiver reentrancy");
+        if (_receiveEntered != _NOT_ENTERED) {
+            revert ReceiverReentrancy();
+        }
         _receiveEntered = _ENTERED;
         _;
         _receiveEntered = _NOT_ENTERED;

--- a/contracts/src/Teleporter/SafeERC20TransferFrom.sol
+++ b/contracts/src/Teleporter/SafeERC20TransferFrom.sol
@@ -21,6 +21,9 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 library SafeERC20TransferFrom {
     using SafeERC20 for IERC20;
 
+    // Errors
+    error BalanceUnchanged();
+
     function safeTransferFrom(
         IERC20 erc20,
         uint256 amount
@@ -29,10 +32,9 @@ library SafeERC20TransferFrom {
         erc20.safeTransferFrom(msg.sender, address(this), amount);
         uint256 balanceAfter = erc20.balanceOf(address(this));
 
-        require(
-            balanceAfter > balanceBefore,
-            "Balanced unchanged after safe transfer."
-        );
+        if (balanceAfter <= balanceBefore) {
+            revert BalanceUnchanged();
+        }
 
         return balanceAfter - balanceBefore;
     }

--- a/contracts/src/Teleporter/TeleporterMessenger.sol
+++ b/contracts/src/Teleporter/TeleporterMessenger.sol
@@ -80,6 +80,23 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
     // The blockchain ID of the chain the contract is deployed on. Determined by warp messenger precompile.
     bytes32 public immutable blockchainID;
 
+    // Errors
+    error MessageNotFound();
+    error MessageAlreadyDelivered();
+    error InvalidMessageHash();
+    error InvalidAdditionalFeeAmount();
+    error InvalidFeeAssetContractAddress();
+    error InvalidRelayerRewardAddress();
+    error InvalidWarpMessage();
+    error InvalidOriginSenderAddress();
+    error InvalidDestinationChainID();
+    error InvalidDestinationAddress();
+    error UnauthorizedRelayer();
+    error MessageRetryExecutionFailed();
+    error NoRelayerRewardToRedeem();
+    error InsufficientGas();
+    error ReceiptNotFound();
+
     /**
      * @dev Sets the value of `blockchainID` to the value determined by the warp messenger precompile.
      */
@@ -132,14 +149,16 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
         bytes32 messageHash = sentMessageInfo[destinationChainID][
             message.messageID
         ].messageHash;
-        require(messageHash != bytes32(0), "Message to be retried not found.");
+        if (messageHash == bytes32(0)) {
+            // If the message hash is zero, the message was never sent.
+            revert MessageNotFound();
+        }
 
         // Check that the hash of the provided message matches the one that was originally submitted.
         bytes memory messageBytes = abi.encode(message);
-        require(
-            keccak256(messageBytes) == messageHash,
-            "Invalid message hash."
-        );
+        if (keccak256(messageBytes) != messageHash) {
+            revert InvalidMessageHash();
+        }
 
         // Emit and make state variable changes before external calls when possible,
         // though this function is protected by sender reentrancy guard.
@@ -175,35 +194,38 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
         uint256 additionalFeeAmount
     ) external senderNonReentrant {
         // The additional fee amount must be non-zero.
-        require(additionalFeeAmount > 0, "Invalid additional fee amount.");
+        if (additionalFeeAmount == 0) {
+            revert InvalidAdditionalFeeAmount();
+        }
 
         // Do not allow adding a fee asset with contract address zero.
-        require(
-            feeContractAddress != address(0),
-            "Invalid fee asset contract address."
-        );
+        if (feeContractAddress == address(0)) {
+            revert InvalidFeeAssetContractAddress();
+        }
 
         // If we have received the delivery receipt for this message, its hash and fee information
         // will be cleared from state. At this point, you can not add to its fee. This is also the
         // case if the given message never existed.
-        require(
-            sentMessageInfo[destinationChainID][messageID].messageHash !=
-                bytes32(0),
-            "Message not found or already delivered."
-        );
+        if (
+            sentMessageInfo[destinationChainID][messageID].messageHash ==
+            bytes32(0)
+        ) {
+            revert MessageAlreadyDelivered();
+        }
 
         // Check that the fee contract address matches the one that was originally used. Only a single
         // fee asset can be used to incentivize the delivery of a given message.
         // We require users to explicitly pass the same fee asset contract address here rather than just using
         // the previously submitted asset type as a defensive measure to avoid having users accidentally confuse
         // which asset they are paying.
-        require(
-            feeContractAddress ==
-                sentMessageInfo[destinationChainID][messageID]
-                    .feeInfo
-                    .contractAddress,
-            "Mismatched fee asset contract address."
-        );
+        if (
+            sentMessageInfo[destinationChainID][messageID]
+                .feeInfo
+                .contractAddress !=
+            feeContractAddress
+        ) {
+            revert InvalidFeeAssetContractAddress();
+        }
 
         // Transfer the additional fee amount to this Teleporter instance.
         uint256 adjustedAmount = SafeERC20TransferFrom.safeTransferFrom(
@@ -243,35 +265,35 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
     ) external receiverNonReentrant {
         // The relayer reward address is not allowed to be the zero address because it is how we track
         // whether or not a message has been delivered.
-        require(
-            relayerRewardAddress != address(0),
-            "Invalid relayer reward address."
-        );
+        if (relayerRewardAddress == address(0)) {
+            revert InvalidRelayerRewardAddress();
+        }
 
         // Verify and parse the cross chain message included in the transaction access list
         // using the warp message precompile.
         (WarpMessage memory warpMessage, bool success) = WARP_MESSENGER
             .getVerifiedWarpMessage();
-        require(success, "Failed to verify or parse cross chain message.");
+
+        if (!success) {
+            revert InvalidWarpMessage();
+        }
 
         // Only allow for messages to be received from the same address as this teleporter contract.
         // The contract should be deployed using the universal deployer pattern, such that it knows messages
         // received from the same address on other chains were constructed using the same bytecode of this contract.
         // This allows for trusting the message format and uniqueness as specified by sendCrossChainMessage.
-        require(
-            warpMessage.originSenderAddress == address(this),
-            "Invalid cross chain message sender address."
-        );
+        if (warpMessage.originSenderAddress != address(this)) {
+            revert InvalidOriginSenderAddress();
+        }
 
         // Require that the message was intended for this blockchain and teleporter contract.
-        require(
-            warpMessage.destinationChainID == blockchainID,
-            "Invalid destination chain ID."
-        );
-        require(
-            warpMessage.destinationAddress == address(this),
-            "Invalid destination address of cross chain message."
-        );
+        if (warpMessage.destinationChainID != blockchainID) {
+            revert InvalidDestinationChainID();
+        }
+
+        if (warpMessage.destinationAddress != address(this)) {
+            revert InvalidDestinationAddress();
+        }
 
         // Parse the payload of the message.
         TeleporterMessage memory teleporterMessage = abi.decode(
@@ -281,21 +303,23 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
 
         // Check the message has not been delivered before by checking that there is no relayer reward
         // address stored for it already.
-        require(
+        if (
             relayerRewardAddresses[warpMessage.originChainID][
                 teleporterMessage.messageID
-            ] == address(0),
-            "Teleporter message previously delivered."
-        );
+            ] != address(0)
+        ) {
+            revert MessageAlreadyDelivered();
+        }
 
         // Check that the caller is allowed to deliver this message.
-        require(
-            _checkIsAllowedRelayer(
+        if (
+            !_checkIsAllowedRelayer(
                 msg.sender,
                 teleporterMessage.allowedRelayerAddresses
-            ),
-            "Unauthorized relayer."
-        );
+            )
+        ) {
+            revert UnauthorizedRelayer();
+        }
 
         // Store the relayer reward address provided, effectively marking the message as received.
         relayerRewardAddresses[warpMessage.originChainID][
@@ -363,22 +387,20 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
         bytes32 failedMessageHash = receivedFailedMessageHashes[originChainID][
             message.messageID
         ];
-        require(
-            failedMessageHash != bytes32(0),
-            "Message execution to retry not found."
-        );
-        require(
-            keccak256(abi.encode(message)) == failedMessageHash,
-            "Invalid payload hash to retry."
-        );
+        if (failedMessageHash == bytes32(0)) {
+            revert MessageNotFound();
+        }
+
+        if (keccak256(abi.encode(message)) != failedMessageHash) {
+            revert InvalidMessageHash();
+        }
 
         // Check that the target address has fully initialized contract code prior to calling it.
         // If the target address does not have code, the execution automatically fails because
         // we disallow calling EOA addresses.
-        require(
-            message.destinationAddress.code.length > 0,
-            "Destination address not a contract."
-        );
+        if (message.destinationAddress.code.length == 0) {
+            revert InvalidDestinationAddress();
+        }
 
         // Clear the failed message hash from state prior to retrying its execution to redundantly prevent
         // reentrance attacks (on top of the nonReentrant guard).
@@ -398,7 +420,9 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
                 (originChainID, message.senderAddress, message.message)
             )
         );
-        require(success, "Message retry execution attempt failed.");
+        if (!success) {
+            revert MessageRetryExecutionFailed();
+        }
     }
 
     /**
@@ -435,7 +459,9 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
             address relayerRewardAddress = relayerRewardAddresses[
                 originChainID
             ][receivedMessageID];
-            require(relayerRewardAddress != address(0), "Receipt not found.");
+            if (relayerRewardAddress == address(0)) {
+                revert ReceiptNotFound();
+            }
 
             receiptsToSend[i] = TeleporterMessageReceipt({
                 receivedMessageID: receivedMessageID,
@@ -464,7 +490,9 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
      */
     function redeemRelayerRewards(address feeAsset) external {
         uint256 rewardAmount = relayerRewardAmounts[msg.sender][feeAsset];
-        require(rewardAmount > 0, "No relayer reward to redeem.");
+        if (rewardAmount == 0) {
+            revert NoRelayerRewardToRedeem();
+        }
 
         // Zero the reward balance before calling the external ERC20 to transfer the
         // reward to prevent any possible re-entrancy.
@@ -589,10 +617,9 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
         uint256 adjustedFeeAmount = 0;
         if (feeInfo.amount > 0) {
             // If the fee amount is non-zero, check that the contract address is not address(0)
-            require(
-                feeInfo.contractAddress != address(0),
-                "Invalid fee asset contract address."
-            );
+            if (feeInfo.contractAddress == address(0)) {
+                revert InvalidFeeAssetContractAddress();
+            }
 
             adjustedFeeAmount = SafeERC20TransferFrom.safeTransferFrom(
                 IERC20(feeInfo.contractAddress),
@@ -684,10 +711,9 @@ contract TeleporterMessenger is ITeleporterMessenger, ReentrancyGuards {
         // its execution succeeds, such that the relayer can claim their fee reward. However, if the message
         // execution fails, the message hash will be stored in state such that anyone can try to provide more
         // gas to successfully execute the message.
-        require(
-            gasleft() >= message.requiredGasLimit,
-            "Insufficient gas provided to execute message."
-        );
+        if (gasleft() < message.requiredGasLimit) {
+            revert InsufficientGas();
+        }
 
         // The destination address must have fully initialized contract code in order for the message
         // to call it. If the destination address does not have code, we store the message as a failed

--- a/contracts/src/Teleporter/tests/AddFeeAmountTests.t.sol
+++ b/contracts/src/Teleporter/tests/AddFeeAmountTests.t.sol
@@ -64,7 +64,7 @@ contract AddFeeAmountTest is TeleporterMessengerTest {
         // Add to the fee amount of a message that doesn't exist. Expect revert.
         uint256 additionalFeeAmount = 131313;
         uint256 fakeMessageID = 13;
-        vm.expectRevert("Message not found or already delivered.");
+        vm.expectRevert(TeleporterMessenger.MessageAlreadyDelivered.selector);
         teleporterMessenger.addFeeAmount(
             DEFAULT_DESTINATION_CHAIN_ID,
             fakeMessageID,
@@ -99,7 +99,7 @@ contract AddFeeAmountTest is TeleporterMessengerTest {
 
         // Now try to add to the fee of the message. Should revert since the message receipt was received already.
         uint256 additionalFeeAmount = 131313;
-        vm.expectRevert("Message not found or already delivered.");
+        vm.expectRevert(TeleporterMessenger.MessageAlreadyDelivered.selector);
         teleporterMessenger.addFeeAmount(
             DEFAULT_DESTINATION_CHAIN_ID,
             messageID,
@@ -118,7 +118,7 @@ contract AddFeeAmountTest is TeleporterMessengerTest {
 
         // Expect revert when adding 0 additional amount.
         uint256 additionalFeeAmount = 0;
-        vm.expectRevert("Invalid additional fee amount.");
+        vm.expectRevert(TeleporterMessenger.InvalidAdditionalFeeAmount.selector);
         teleporterMessenger.addFeeAmount(
             DEFAULT_DESTINATION_CHAIN_ID,
             messageID,
@@ -138,7 +138,7 @@ contract AddFeeAmountTest is TeleporterMessengerTest {
         // Expect revert when using a different fee asset than originally used.
         uint256 additionalFeeAmount = 131313;
         address differentFeeAsset = 0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664;
-        vm.expectRevert("Mismatched fee asset contract address.");
+        vm.expectRevert(TeleporterMessenger.InvalidFeeAssetContractAddress.selector);
         teleporterMessenger.addFeeAmount(
             DEFAULT_DESTINATION_CHAIN_ID,
             messageID,
@@ -158,7 +158,7 @@ contract AddFeeAmountTest is TeleporterMessengerTest {
         // Expect revert when using an invalid fee asset.
         uint256 additionalFeeAmount = 131313;
         address invalidFeeAsset = address(0);
-        vm.expectRevert("Invalid fee asset contract address.");
+        vm.expectRevert(TeleporterMessenger.InvalidFeeAssetContractAddress.selector);
         teleporterMessenger.addFeeAmount(
             DEFAULT_DESTINATION_CHAIN_ID,
             messageID,

--- a/contracts/src/Teleporter/tests/HandleInitialMessageExecutionTests.t.sol
+++ b/contracts/src/Teleporter/tests/HandleInitialMessageExecutionTests.t.sol
@@ -19,6 +19,11 @@ contract SampleMessageReceiver is ITeleporterReceiver {
     bytes32 public latestMessageSenderSubnetID;
     address public latestMessageSenderAddress;
 
+    // Errors
+    error Unauthorized();
+    error InvalidAction();
+    error IntendedToFail();
+
     constructor(address teleporterContractAddress) {
         teleporterContract = teleporterContractAddress;
     }
@@ -28,7 +33,9 @@ contract SampleMessageReceiver is ITeleporterReceiver {
         address originSenderAddress,
         bytes calldata message
     ) external {
-        require(msg.sender == teleporterContract, "Unauthorized.");
+        if (msg.sender != teleporterContract) {
+            revert Unauthorized();
+        }
         // Decode the payload to recover the action and corresponding function parameters
         (SampleMessageReceiverAction action, bytes memory actionData) = abi
             .decode(message, (SampleMessageReceiverAction, bytes));
@@ -51,7 +58,7 @@ contract SampleMessageReceiver is ITeleporterReceiver {
                 messageString
             );
         } else {
-            revert("Invalid action.");
+            revert InvalidAction();
         }
     }
 
@@ -62,8 +69,13 @@ contract SampleMessageReceiver is ITeleporterReceiver {
         string memory message,
         bool succeed
     ) internal {
-        require(msg.sender == teleporterContract, "Unauthorized.");
-        require(succeed, "Intended to fail.");
+        if (msg.sender != teleporterContract) {
+            revert Unauthorized();
+        }
+
+        if (!succeed) {
+            revert IntendedToFail();
+        }
         latestMessage = message;
         latestMessageSenderSubnetID = originChainID;
         latestMessageSenderAddress = originSenderAddress;
@@ -75,7 +87,9 @@ contract SampleMessageReceiver is ITeleporterReceiver {
         address originSenderAddress,
         string memory message
     ) internal {
-        require(msg.sender == teleporterContract, "Unauthorized.");
+        if (msg.sender != teleporterContract) {
+            revert Unauthorized();
+        }
         ITeleporterMessenger messenger = ITeleporterMessenger(
             teleporterContract
         );
@@ -174,7 +188,7 @@ contract HandleInitialMessageExecutionTest is TeleporterMessengerTest {
         _setUpSuccessGetVerifiedWarpMessageMock(warpMessage);
 
         // Receive the message.
-        vm.expectRevert("Insufficient gas provided to execute message.");
+        vm.expectRevert(TeleporterMessenger.InsufficientGas.selector);
         teleporterMessenger.receiveCrossChainMessage(
             DEFAULT_RELAYER_REWARD_ADDRESS
         );
@@ -227,7 +241,7 @@ contract HandleInitialMessageExecutionTest is TeleporterMessengerTest {
             ),
             DEFAULT_RELAYER_REWARD_ADDRESS
         );
-        vm.expectRevert("Message retry execution attempt failed.");
+        vm.expectRevert(TeleporterMessenger.MessageRetryExecutionFailed.selector);
         teleporterMessenger.retryMessageExecution(
             DEFAULT_ORIGIN_CHAIN_ID,
             messageToReceive
@@ -279,7 +293,7 @@ contract HandleInitialMessageExecutionTest is TeleporterMessengerTest {
             ),
             DEFAULT_RELAYER_REWARD_ADDRESS
         );
-        vm.expectRevert("Message retry execution attempt failed.");
+        vm.expectRevert(TeleporterMessenger.MessageRetryExecutionFailed.selector);
         teleporterMessenger.retryMessageExecution(
             DEFAULT_ORIGIN_CHAIN_ID,
             messageToReceive

--- a/contracts/src/Teleporter/tests/ReceiptsQueueTests.t.sol
+++ b/contracts/src/Teleporter/tests/ReceiptsQueueTests.t.sol
@@ -57,7 +57,7 @@ contract ReceiptQueueTest is Test {
         assertEq(queue.size(), 0);
 
         // Check that you can't dequeue anything else.
-        vm.expectRevert("Empty queue.");
+        vm.expectRevert(ReceiptQueue.EmptyQueue.selector);
         result = queue.dequeue();
 
         // Enqueue two more of the same item to check you can have duplicates, followed by the second and third.
@@ -72,9 +72,9 @@ contract ReceiptQueueTest is Test {
         // Make sure a non-queue owner can't call any of the methods.
         address badCaller = 0x31a817802EE183eb8B13167fFE24bD28DcC6f30c;
         vm.startPrank(badCaller);
-        vm.expectRevert("Unauthorized.");
+        vm.expectRevert(ReceiptQueue.Unauthorized.selector);
         queue.enqueue(receipt1);
-        vm.expectRevert("Unauthorized.");
+        vm.expectRevert(ReceiptQueue.Unauthorized.selector);
         result = queue.dequeue();
         vm.stopPrank();
 

--- a/contracts/src/Teleporter/tests/ReceiveCrossChainMessageTests.t.sol
+++ b/contracts/src/Teleporter/tests/ReceiveCrossChainMessageTests.t.sol
@@ -71,7 +71,7 @@ contract ReceiveCrossChainMessagedTest is TeleporterMessengerTest {
             abi.encodeCall(WarpMessenger.getVerifiedWarpMessage, ())
         );
 
-        vm.expectRevert("Failed to verify or parse cross chain message.");
+        vm.expectRevert(TeleporterMessenger.InvalidWarpMessage.selector);
         teleporterMessenger.receiveCrossChainMessage(address(1));
     }
 
@@ -93,7 +93,7 @@ contract ReceiveCrossChainMessagedTest is TeleporterMessengerTest {
         // Mock the call to the warp precompile to get the message.
         _setUpSuccessGetVerifiedWarpMessageMock(warpMessage);
 
-        vm.expectRevert("Invalid cross chain message sender address.");
+        vm.expectRevert(TeleporterMessenger.InvalidOriginSenderAddress.selector);
         teleporterMessenger.receiveCrossChainMessage(
             DEFAULT_RELAYER_REWARD_ADDRESS
         );
@@ -119,7 +119,7 @@ contract ReceiveCrossChainMessagedTest is TeleporterMessengerTest {
         // Mock the call to the warp precompile to get the message.
         _setUpSuccessGetVerifiedWarpMessageMock(warpMessage);
 
-        vm.expectRevert("Invalid destination chain ID.");
+        vm.expectRevert(TeleporterMessenger.InvalidDestinationChainID.selector);
         teleporterMessenger.receiveCrossChainMessage(
             DEFAULT_RELAYER_REWARD_ADDRESS
         );
@@ -143,14 +143,14 @@ contract ReceiveCrossChainMessagedTest is TeleporterMessengerTest {
         // Mock the call to the warp precompile to get the message.
         _setUpSuccessGetVerifiedWarpMessageMock(warpMessage);
 
-        vm.expectRevert("Invalid destination address of cross chain message.");
+        vm.expectRevert(TeleporterMessenger.InvalidDestinationAddress.selector);
         teleporterMessenger.receiveCrossChainMessage(
             DEFAULT_RELAYER_REWARD_ADDRESS
         );
     }
 
     function testInvalidRelayerAddress() public {
-        vm.expectRevert("Invalid relayer reward address.");
+        vm.expectRevert(TeleporterMessenger.InvalidRelayerRewardAddress.selector);
         teleporterMessenger.receiveCrossChainMessage(address(0));
     }
 
@@ -159,7 +159,7 @@ contract ReceiveCrossChainMessagedTest is TeleporterMessengerTest {
         testSuccess();
 
         // Check you can't deliver it again.
-        vm.expectRevert("Teleporter message previously delivered.");
+        vm.expectRevert(TeleporterMessenger.MessageAlreadyDelivered.selector);
         teleporterMessenger.receiveCrossChainMessage(
             DEFAULT_RELAYER_REWARD_ADDRESS
         );
@@ -190,7 +190,7 @@ contract ReceiveCrossChainMessagedTest is TeleporterMessengerTest {
         _setUpSuccessGetVerifiedWarpMessageMock(warpMessage);
 
         // Receive the message.
-        vm.expectRevert("Unauthorized relayer.");
+        vm.expectRevert(TeleporterMessenger.UnauthorizedRelayer.selector);
         teleporterMessenger.receiveCrossChainMessage(
             DEFAULT_RELAYER_REWARD_ADDRESS
         );

--- a/contracts/src/Teleporter/tests/RedeemRelayerRewardsTests.t.sol
+++ b/contracts/src/Teleporter/tests/RedeemRelayerRewardsTests.t.sol
@@ -22,7 +22,7 @@ contract RedeemRelayerRewardsTest is TeleporterMessengerTest {
     }
 
     function testZeroRewardBalance() public {
-        vm.expectRevert("No relayer reward to redeem.");
+        vm.expectRevert(TeleporterMessenger.NoRelayerRewardToRedeem.selector);
         teleporterMessenger.redeemRelayerRewards(address(_mockFeeAsset));
     }
 

--- a/contracts/src/Teleporter/tests/RetryMessageExecutionTests.t.sol
+++ b/contracts/src/Teleporter/tests/RetryMessageExecutionTests.t.sol
@@ -22,6 +22,11 @@ contract FlakyMessageReceiver is ITeleporterReceiver {
     bytes32 public latestMessageSenderSubnetID;
     address public latestMessageSenderAddress;
 
+    // Errors
+    error Unauthorized();
+    error InvalidAction();
+    error EvenBlockNumber();
+
     constructor(address teleporterContractAddress) {
         teleporterContract = teleporterContractAddress;
     }
@@ -31,7 +36,9 @@ contract FlakyMessageReceiver is ITeleporterReceiver {
         address originSenderAddress,
         bytes calldata messageBytes
     ) external {
-        require(msg.sender == teleporterContract, "Unauthorized.");
+        if (msg.sender != teleporterContract) {
+            revert Unauthorized();
+        }
         // Decode the payload to recover the action and corresponding function parameters
         (FlakyMessageReceiverAction action, bytes memory actionData) = abi
             .decode(messageBytes, (FlakyMessageReceiverAction, bytes));
@@ -42,7 +49,7 @@ contract FlakyMessageReceiver is ITeleporterReceiver {
             string memory message = abi.decode(actionData, (string));
             _retryReceive(originChainID, originSenderAddress, message);
         } else {
-            revert("Invalid action.");
+            revert InvalidAction();
         }
     }
 
@@ -52,8 +59,12 @@ contract FlakyMessageReceiver is ITeleporterReceiver {
         address originSenderAddress,
         string memory message
     ) internal {
-        require(msg.sender == teleporterContract, "Unauthorized.");
-        require(block.number % 2 != 0, "Even block number.");
+        if (msg.sender != teleporterContract) {
+            revert Unauthorized();
+        }
+        if (block.number % 2 == 0) {
+            revert EvenBlockNumber();
+        }
         latestMessage = message;
         latestMessageSenderSubnetID = originChainID;
         latestMessageSenderAddress = originSenderAddress;
@@ -65,8 +76,12 @@ contract FlakyMessageReceiver is ITeleporterReceiver {
         address originSenderAddress,
         string memory message
     ) internal {
-        require(msg.sender == teleporterContract, "Unauthorized.");
-        require(block.number % 2 != 0, "Even block number.");
+        if (msg.sender != teleporterContract) {
+            revert Unauthorized();
+        }
+        if (block.number % 2 == 0) {
+            revert EvenBlockNumber();
+        }
 
         ITeleporterMessenger messenger = ITeleporterMessenger(
             teleporterContract
@@ -104,7 +119,7 @@ contract RetryMessageExecutionTest is TeleporterMessengerTest {
         ) = _receiveFailedMessage(false);
 
         // Now retry it in another block with an even timestamp so that it fails again.
-        vm.expectRevert("Message retry execution attempt failed.");
+        vm.expectRevert(TeleporterMessenger.MessageRetryExecutionFailed.selector);
         teleporterMessenger.retryMessageExecution(originChainID, message);
     }
 
@@ -120,7 +135,7 @@ contract RetryMessageExecutionTest is TeleporterMessengerTest {
             message: new bytes(0)
         });
 
-        vm.expectRevert("Message execution to retry not found.");
+        vm.expectRevert(TeleporterMessenger.MessageNotFound.selector);
         teleporterMessenger.retryMessageExecution(
             DEFAULT_ORIGIN_CHAIN_ID,
             fakeMessage
@@ -137,7 +152,7 @@ contract RetryMessageExecutionTest is TeleporterMessengerTest {
 
         // Alter the message before retrying it.
         message.message = "altered message";
-        vm.expectRevert("Invalid payload hash to retry.");
+        vm.expectRevert(TeleporterMessenger.InvalidMessageHash.selector);
         teleporterMessenger.retryMessageExecution(originChainID, message);
     }
 
@@ -149,7 +164,7 @@ contract RetryMessageExecutionTest is TeleporterMessengerTest {
         ) = _successfullyRetryMessage();
 
         // Now try again and make sure it's been cleared from state
-        vm.expectRevert("Message execution to retry not found.");
+        vm.expectRevert(TeleporterMessenger.MessageNotFound.selector);
         teleporterMessenger.retryMessageExecution(originChainID, message);
     }
 
@@ -191,7 +206,7 @@ contract RetryMessageExecutionTest is TeleporterMessengerTest {
 
         // Retrying the message execution should revert since there is still no contract deployed
         // to the destination address.
-        vm.expectRevert("Destination address not a contract.");
+        vm.expectRevert(TeleporterMessenger.InvalidDestinationAddress.selector);
         teleporterMessenger.retryMessageExecution(originChainID, message);
     }
 

--- a/contracts/src/Teleporter/tests/RetryReceiptTests.t.sol
+++ b/contracts/src/Teleporter/tests/RetryReceiptTests.t.sol
@@ -168,7 +168,7 @@ contract RetryReceiptTest is TeleporterMessengerTest {
         missingIDs[0] = 21;
 
         // Try to retry a receipt for an unreceived message from that chain - should fail.
-        vm.expectRevert("Receipt not found.");
+        vm.expectRevert(TeleporterMessenger.ReceiptNotFound.selector);
         _retryTestReceiptsWithNoFee(DEFAULT_DESTINATION_CHAIN_ID, missingIDs);
     }
 

--- a/contracts/src/Teleporter/tests/RetrySendCrossChainMessageTests.t.sol
+++ b/contracts/src/Teleporter/tests/RetrySendCrossChainMessageTests.t.sol
@@ -48,7 +48,7 @@ contract RetrySendCrossChainMessageTest is TeleporterMessengerTest {
             receipts: new TeleporterMessageReceipt[](0),
             message: new bytes(0)
         });
-        vm.expectRevert("Message to be retried not found.");
+        vm.expectRevert(TeleporterMessenger.MessageNotFound.selector);
         teleporterMessenger.retrySendCrossChainMessage(
             DEFAULT_DESTINATION_CHAIN_ID,
             fakeMessage
@@ -72,7 +72,7 @@ contract RetrySendCrossChainMessageTest is TeleporterMessengerTest {
         });
 
         // Retry it - should fail.
-        vm.expectRevert("Invalid message hash.");
+        vm.expectRevert(TeleporterMessenger.InvalidMessageHash.selector);
         teleporterMessenger.retrySendCrossChainMessage(
             DEFAULT_DESTINATION_CHAIN_ID,
             alteredMessage

--- a/contracts/src/Teleporter/tests/SendCrossChainMessageTests.t.sol
+++ b/contracts/src/Teleporter/tests/SendCrossChainMessageTests.t.sol
@@ -200,7 +200,7 @@ contract SendCrossChainMessageTest is TeleporterMessengerTest {
             message: new bytes(0)
         });
 
-        vm.expectRevert("Invalid fee asset contract address.");
+        vm.expectRevert(TeleporterMessenger.InvalidFeeAssetContractAddress.selector);
         teleporterMessenger.sendCrossChainMessage(messageInput);
     }
 }


### PR DESCRIPTION
## Why this should be merged
- Replace revert a message with a custom error
- Turn on `custom-errors warning` in the solhint.json config to do lint for the [rule](https://github.com/protofire/solhint/blob/master/docs/rules/best-practises/custom-errors.md)

## How this was tested
- Unit tests
