### PR TITLE
Show changed files in ABI bindings check

### DIFF
--- a/.github/workflows/abi_go_bindings_checker.yml
+++ b/.github/workflows/abi_go_bindings_checker.yml
@@ -1,6 +1,9 @@
 name: ABI Go Bindings Checker
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/check_clean_branch.sh
+++ b/.github/workflows/check_clean_branch.sh
@@ -9,4 +9,4 @@ set -o pipefail
 # Checks to see if merges or updates are needed by checking stat() information.
 git update-index --really-refresh > /dev/null
 # Checks to see if there are any differences from the index to the current HEAD commit
-git diff-index --quiet HEAD
+git diff-index HEAD --exit-code


### PR DESCRIPTION
## Why this should be merged & How this works
Removes the `--quiet` option so that the modified files are listed. Also runs the workflow on pushes to `main` this should be redundant, but accounts for merge commits.

## How this was tested
N/A

## How is this documented
N/A