### PR TITLE
Exit on error in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@
 
 FROM ubuntu:20.04
 
+RUN set -e
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 # defaults to amd64. needs to be arm64 for Macos M1

--- a/scripts/local/test.sh
+++ b/scripts/local/test.sh
@@ -50,6 +50,7 @@ setARCH
 if [ -z "$LOCAL_RELAYER_IMAGE" ]; then
     echo "Using published awm-relayer image"
     docker compose -f docker/docker-compose-test.yml --project-directory ./ up --build &
+    dockerPid=$!
 else
     echo "Using local awm-relayer image: $LOCAL_RELAYER_IMAGE"
     if [[ "$(docker images -q awm-relayer:$LOCAL_RELAYER_IMAGE 2> /dev/null)" == "" ]]; then
@@ -59,11 +60,18 @@ else
     rm -f docker/docker-compose-test-local.yml
     sed "s/<TAG>/$LOCAL_RELAYER_IMAGE/g" docker/docker-compose-test-local-template.yml > docker/docker-compose-test-local.yml
     docker compose -f docker/docker-compose-test-local.yml --project-directory ./ up --build &
+    dockerPid=$!
 fi
 
 # Wait for the containers to start up
 until [ "$( docker container inspect --format '{{.State.Running}}' test_runner )" == "true" ]
 do
+    if ! ps -p $dockerPid > /dev/null
+    then
+        echo "Docker process is dead"
+        exit 1
+    fi
+
     echo "Waiting for containers to start..."
     sleep 1
 done


### PR DESCRIPTION
## Why this should be merged
This will cause integration tests to exit on the first error in the dockerfile, making it easier to debug issues.

## How this works
Set -e in dockerfile
`test.sh` will check to see if the PID for the docker process still exists while waiting for container to start up.

## How this was tested

## How is this documented