### PR TITLE
pull from ava-labs/foundry

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ ENV LANG en_US.utf8
 # Install foundry from specific commit
 SHELL ["/bin/bash", "-c"]
 RUN curl -L https://raw.githubusercontent.com/ava-labs/foundry/v0.1.0/foundryup/install > /tmp/foundry-install-script && \
+    sed -i 's/\/ava-labs\/foundry\/master\/foundryup/\/ava-labs\/foundry\/v0.1.0\/foundryup/g' /tmp/foundry-install-script && \
     cat /tmp/foundry-install-script | bash && \
     echo "export PATH=\"$PATH:/$HOME/.foundry/bin\"">> ~/.bashrc && \
     source ~/.bashrc && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,13 +36,12 @@ ENV LANG en_US.utf8
 
 # Install foundry from specific commit
 SHELL ["/bin/bash", "-c"]
-RUN curl -L https://raw.githubusercontent.com/foundry-rs/foundry/037b3bc9cebd545fe3a4f05a32bf7efb82afdbd8/foundryup/install > /tmp/foundry-install-script && \
-    sed -i 's/\/foundry-rs\/foundry\/master\/foundryup/\/foundry-rs\/foundry\/037b3bc9cebd545fe3a4f05a32bf7efb82afdbd8\/foundryup/g' /tmp/foundry-install-script && \
+RUN curl -L https://raw.githubusercontent.com/ava-labs/foundry/master/foundryup/install > /tmp/foundry-install-script && \
     cat /tmp/foundry-install-script | bash && \
     echo "export PATH=\"$PATH:/$HOME/.foundry/bin\"">> ~/.bashrc && \
     source ~/.bashrc && \
     export PATH=$PATH:$HOME/.foundry/bin:$HOME/.cargo/bin && \
-    foundryup --version nightly-037b3bc9cebd545fe3a4f05a32bf7efb82afdbd8
+    foundryup --version v0.1.0
 
 # Install python base58 decode library
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ ENV LANG en_US.utf8
 
 # Install foundry from specific commit
 SHELL ["/bin/bash", "-c"]
-RUN curl -L https://raw.githubusercontent.com/ava-labs/foundry/master/foundryup/install > /tmp/foundry-install-script && \
+RUN curl -L https://raw.githubusercontent.com/ava-labs/foundry/v0.1.0/foundryup/install > /tmp/foundry-install-script && \
     cat /tmp/foundry-install-script | bash && \
     echo "export PATH=\"$PATH:/$HOME/.foundry/bin\"">> ~/.bashrc && \
     source ~/.bashrc && \

--- a/scripts/fuji/example-workflows/bridge_erc20_tokens.sh
+++ b/scripts/fuji/example-workflows/bridge_erc20_tokens.sh
@@ -19,7 +19,7 @@ echo "Bridged ERC20 balance on Conduit Subnet: $subnet_c_bridged_token_balance"
 cast send $subnet_a_native_erc20_contract "approve(address,uint256)(bool)" $subnet_a_erc20_bridge_contract 400000000000000000 \
     --private-key $user_private_key --rpc-url $subnet_a_url
 result=$(cast call $subnet_a_native_erc20_contract "allowance(address,address)(uint256)" $user_address $subnet_a_erc20_bridge_contract --rpc-url $subnet_a_url)
-if [[ $result != 400000000000000000 ]]; then
+if [[ $result -ne 400000000000000000 ]]; then
     echo "Allowance $result"
     echo "Error approving bridge contract on Amplify Subnet to spend ERC20 from user account."
     exit 1
@@ -51,11 +51,11 @@ subnet_b_bridged_token_balance=$(cast call $subnet_b_bridge_token_contract "bala
 retry_count=0
 until [[ $native_erc20_balance = $native_erc20_expected_balance ]] && [[ $subnet_b_bridged_token_balance = $subnet_b_bridged_token_expected_balance ]]; do
     if [[ retry_count -ge 10 ]]; then
-        if [[ $native_erc20_balance != $native_erc20_expected_balance ]]; then
+        if [[ $native_erc20_balance -ne $native_erc20_expected_balance ]]; then
             echo "Native ERC20 balance for $user_address did not match expected on Amplify Subnet."
             echo "Actual balance: $native_erc20_balance, Expected: $native_erc20_expected_balance"
         fi
-        if [[ $subnet_b_bridged_token_balance != $subnet_b_bridged_token_expected_balance ]]; then
+        if [[ $subnet_b_bridged_token_balance -ne $subnet_b_bridged_token_expected_balance ]]; then
             echo "Bridge token balance for $user_address did not match expected on Bulletin Subnet."
             echo "Actual balance: $subnet_b_bridged_token_balance, Expected: $subnet_b_bridged_token_expected_balance"
         fi
@@ -78,7 +78,7 @@ echo "Bridge token balance matches expected."
 cast send $subnet_b_bridge_token_contract "approve(address,uint256)(bool)" $subnet_b_erc20_bridge_contract 200000000000000000 \
     --private-key $user_private_key --rpc-url $subnet_b_url
 result=$(cast call $subnet_b_bridge_token_contract "allowance(address,address)(uint256)" $user_address $subnet_b_erc20_bridge_contract --rpc-url $subnet_b_url)
-if [[ $result != 200000000000000000 ]]; then
+if [[ $result -ne 200000000000000000 ]]; then
     echo $result
     echo "Error approving bridge contract on Bulletin Subnet to spend bridged ERC20 from user account."
     exit 1
@@ -110,11 +110,11 @@ subnet_c_bridged_token_balance=$(cast call $subnet_c_bridge_token_contract "bala
 retry_count=0
 until [[ $subnet_b_bridged_token_balance = $subnet_b_bridged_token_expected_balance ]] && [[ $subnet_c_bridged_token_balance = $subnet_c_bridged_token_expected_balance ]]; do
     if [[ retry_count -ge 10 ]]; then
-        if [[ $subnet_b_bridged_token_balance != $subnet_b_bridged_token_expected_balance ]]; then
+        if [[ $subnet_b_bridged_token_balance -ne $subnet_b_bridged_token_expected_balance ]]; then
             echo "Bridge token balance for $user_address did not match expected on Bulletin Subnet."
             echo "Actual balance: $subnet_b_bridged_token_balance, Expected: $subnet_b_bridged_token_expected_balance"
         fi
-        if [[ $subnet_c_bridged_token_balance != $subnet_c_bridged_token_expected_balance ]]; then
+        if [[ $subnet_c_bridged_token_balance -ne $subnet_c_bridged_token_expected_balance ]]; then
             echo "Bridge token balance for $user_address did not match expected on Conduit Subnet."
             echo "Actual balance: $subnet_c_bridged_token_balance, Expected: $subnet_c_bridged_token_expected_balance"
         fi

--- a/scripts/local/integration-tests/basic_send_receive.sh
+++ b/scripts/local/integration-tests/basic_send_receive.sh
@@ -65,8 +65,9 @@ cast send $erc20_contract_address_a "approve(address,uint256)(bool)" $teleporter
     $approve_amount \
     --private-key $user_private_key --rpc-url $subnet_a_url
 result=$(cast call $erc20_contract_address_a "allowance(address,address)(uint256)" $user_address $teleporter_contract_address --rpc-url $subnet_a_url)
-if [[ $result != $approve_amount ]]; then
+if [[ $result -ne $approve_amount ]]; then
     echo $result
+    echo $approve_amount
     echo "Error approving Teleporter contract to spend ERC20 from user account."
     exit 1
 fi
@@ -116,7 +117,7 @@ send_cross_subnet_message_message_data=cafebabecafebabecafebabecafebabecafebabec
 # Approve the teleporter contract to some ERC20 tokens from the user account we're using to send transactions
 cast send $erc20_contract_address_b "approve(address,uint256)(bool)" $teleporter_contract_address $approve_amount --private-key $user_private_key --rpc-url $subnet_b_url
 result=$(cast call $erc20_contract_address_b "allowance(address,address)(uint256)" $user_address $teleporter_contract_address --rpc-url $subnet_b_url)
-if [[ $result != $approve_amount ]]; then
+if [[ $result -ne $approve_amount ]]; then
     echo $result
     echo "Error approving Teleporter contract to spend ERC20 from user account."
     exit 1

--- a/scripts/local/integration-tests/erc20_bridge_multihop.sh
+++ b/scripts/local/integration-tests/erc20_bridge_multihop.sh
@@ -69,7 +69,7 @@ approve_amount=10000000000000000000000000000000
 cast send $native_erc20_contract_address "approve(address,uint256)(bool)" $bridge_a_address $approve_amount \
     --private-key $user_private_key --rpc-url $subnet_a_url
 result=$(cast call $native_erc20_contract_address "allowance(address,address)(uint256)" $user_address $bridge_a_address --rpc-url $subnet_a_url)
-if [[ $result != $approve_amount ]]; then
+if [[ $result -ne $approve_amount ]]; then
     echo $result
     echo "Error approving bridge contract on subnet A to spend ERC20 from user account."
     exit 1
@@ -169,12 +169,12 @@ if [[ "$actual_native_asset" != "$native_erc20_contract_address" ]]; then
     exit 1
 fi
 
-if [[ $actual_name != "\"Mock Token\"" ]]; then
+if [[ $actual_name != "Mock Token" ]]; then
     echo "Actual name: $actual_name, Expected: Mock Token"
     exit 1
 fi
 
-if [[ $actual_symbol != "\"EXMP\"" ]]; then
+if [[ $actual_symbol != "EXMP" ]]; then
     echo "Actual symbol: $actual_symbol, Expected: EXMP"
     exit 1
 fi
@@ -188,7 +188,7 @@ fi
 actual_bridge_token_balance=$(cast call $bridge_token_subnet_b_contract_address "balanceOf(address)(uint256)" $user_address --rpc-url $subnet_b_url)
 echo "Bridge token balance is $actual_bridge_token_balance"
 
-if [[ "$actual_bridge_token_balance" != "12000000000000000000" ]]; then
+if [[ $actual_bridge_token_balance -ne 12000000000000000000 ]]; then
     echo "Bridge token balance for $user_address did not match expected."
     echo "Actual balance: $actual_bridge_token_balance, Expected: 12000000000000000000"
     exit 1
@@ -198,7 +198,7 @@ echo "Bridge token balance matches expected."
 # Approve the bridge contract on subnet B to spent the wrapped tokens in the user account.
 cast send $bridge_token_subnet_b_contract_address "approve(address,uint256)(bool)" $bridge_b_address $approve_amount --private-key $user_private_key --rpc-url $subnet_b_url
 result=$(cast call $bridge_token_subnet_b_contract_address "allowance(address,address)(uint256)" $user_address $bridge_b_address --rpc-url $subnet_b_url)
-if [[ $result != $approve_amount ]]; then
+if [[ $result -ne $approve_amount ]]; then
     echo $result
     echo "Error approving bridge contract on subnet B to spend bridged ERC20 from user account."
     exit 1
@@ -224,7 +224,7 @@ sleep 10
 actual_bridge_token_balance=$(cast call $bridge_token_subnet_c_contract_address "balanceOf(address)(uint256)" $user_address --rpc-url $subnet_c_url)
 echo "Bridge token balance on Subnet C is $actual_bridge_token_balance"
 
-if [[ "$actual_bridge_token_balance" != "9000000000000000000" ]]; then
+if [[ $actual_bridge_token_balance -ne 9000000000000000000 ]]; then
     echo "Bridge token balance for $user_address on Subnet C did not match expected."
     echo "Actual balance: $actual_bridge_token_balance, Expected: 9000000000000000000"
     exit 1
@@ -235,7 +235,7 @@ echo "Bridge token balance matches expected on Subnet C."
 if [ ! -z "$relayer_address" ]; then
     actual_relayer_redeemable_balance=$(cast call $teleporter_contract_address "checkRelayerRewardAmount(address,address)(uint256)" $relayer_address $native_erc20_contract_address --rpc-url $subnet_a_url)
     echo "Redeemable native ERC20 token balance for relayer account is $actual_relayer_redeemable_balance"
-    if [[ "$actual_relayer_redeemable_balance" != "2000000000000000000" ]]; then
+    if [[ $actual_relayer_redeemable_balance -ne 2000000000000000000 ]]; then
         echo "Redeemable rewards for relayer account ($relayer_address) did not match expected."
         echo "Actual balance: $actual_relayer_redeemable_balance, Expected: 2000000000000000000"
         exit 1
@@ -246,7 +246,7 @@ fi
 # Approve the bridge contract on Subnet C to spend the bridge tokens from the user account
 cast send $bridge_token_subnet_c_contract_address "approve(address,uint256)(bool)" $bridge_c_address $approve_amount --private-key $user_private_key --rpc-url $subnet_c_url
 result=$(cast call $bridge_token_subnet_c_contract_address "allowance(address,address)(uint256)" $user_address $bridge_c_address --rpc-url $subnet_c_url)
-if [[ $result != $approve_amount ]]; then
+if [[ $result -ne $approve_amount ]]; then
     echo $result
     echo "Error approving bridge contract on subnet C to spend bridged ERC20 from user account."
     exit 1
@@ -271,7 +271,7 @@ sleep 10
 # Check the balance of the native token after the unwrap
 actual_native_token_default_account_balance=$(cast call $native_erc20_contract_address "balanceOf(address)(uint256)" $user_address --rpc-url $subnet_a_url)
 echo "Native ERC20 token balance for user account is $actual_native_token_default_account_balance"
-if [[ "$actual_native_token_default_account_balance" != "9999999992000000000000000000" ]]; then
+if [[ $actual_native_token_default_account_balance -ne 9999999992000000000000000000 ]]; then
     echo "Native token balance for $user_address did not match expected."
     echo "Actual balance: $actual_native_token_default_account_balance, Expected: 9999999992000000000000000000"
     exit 1
@@ -282,7 +282,7 @@ echo "Native token balance matches expected for user account."
 if [ ! -z "$relayer_address" ]; then
     actual_relayer_redeemable_balance=$(cast call $teleporter_contract_address "checkRelayerRewardAmount(address,address)(uint256)" $relayer_address $native_erc20_contract_address --rpc-url $subnet_a_url)
     echo "Redeemable ERC20 token reward balance for relayer account is $actual_relayer_redeemable_balance"
-    if [[ "$actual_relayer_redeemable_balance" != "4000000000000000000" ]]; then
+    if [[ $actual_relayer_redeemable_balance -ne 4000000000000000000 ]]; then
         echo "Redeemable reward balance for relayer account ($relayer_address) did not match expected."
         echo "Actual balance: $actual_relayer_redeemable_balance, Expected: 4000000000000000000"
         exit 1

--- a/scripts/local/integration-tests/example_messenger.sh
+++ b/scripts/local/integration-tests/example_messenger.sh
@@ -49,7 +49,7 @@ approve_amount=100000000000000000000000
 cast send $erc20_contract_address "approve(address,uint256)(bool)" $example_messenger_a_contract_address \
     $approve_amount --private-key $user_private_key --rpc-url $subnet_a_url
 result=$(cast call $erc20_contract_address "allowance(address,address)(uint256)" $user_address $example_messenger_a_contract_address --rpc-url $subnet_a_url)
-if [[ $result != $approve_amount ]]; then
+if [[ $result -ne $approve_amount ]]; then
     echo $result
     echo "Error approving example messenger contract to spend ERC20 from user account."
     exit 1
@@ -92,7 +92,7 @@ if [[ $(stringToLower $actual_sender_address) != $origin_contract_address_lower 
 fi
 # Check that the message matched the one submitted to subnet A.
 # The message "hello world!" is returned without quotations, so it is split up as two different values by bash across indices 1 and 2 of the result.
-if [[ "${result_arr[1]} ${result_arr[2]}" != "\"$send_cross_chain_message_message_string\"" ]]; then
+if [[ "${result_arr[1]} ${result_arr[2]}" != "$send_cross_chain_message_message_string" ]]; then
     echo "Get current message returned unexpected message."
     echo "Actual: ${result_arr[1]} ${result_arr[2]}"
     echo "Expected: $send_cross_chain_message_message_string"

--- a/scripts/local/integration-tests/send_specified_receipts.sh
+++ b/scripts/local/integration-tests/send_specified_receipts.sh
@@ -67,7 +67,7 @@ cast send $erc20_contract_address_a "approve(address,uint256)(bool)" $teleporter
     $approve_amount \
     --private-key $user_private_key --rpc-url $subnet_a_url
 result=$(cast call $erc20_contract_address_a "allowance(address,address)(uint256)" $user_address $teleporter_contract_address --rpc-url $subnet_a_url)
-if [[ $result != $approve_amount ]]; then
+if [[ $result -ne $approve_amount ]]; then
     echo $result
     echo "Error approving Teleporter contract to spend ERC20 from user account."
     exit 1
@@ -75,7 +75,7 @@ fi
 
 cast send $erc20_contract_address_b "approve(address,uint256)(bool)" $teleporter_contract_address $approve_amount --private-key $user_private_key --rpc-url $subnet_b_url
 result=$(cast call $erc20_contract_address_b "allowance(address,address)(uint256)" $user_address $teleporter_contract_address --rpc-url $subnet_b_url)
-if [[ $result != $approve_amount ]]; then
+if [[ $result -ne $approve_amount ]]; then
     echo $result
     echo "Error approving Teleporter contract to spend ERC20 from user account."
     exit 1
@@ -139,7 +139,7 @@ if [ ! -z "$relayer_address" ]; then
     echo "Relayer after sendSpecifiedReceipts can redeem rewards of $afterReward"
 
     reward=$(($afterReward-$startingReward))
-    if [[ $reward != $send_cross_subnet_message_fee_amount ]]; then
+    if [[ $reward -ne $send_cross_subnet_message_fee_amount ]]; then
         echo "Relayer reward should be rewarded $send_cross_subnet_message_fee_amount but instead increased by $reward"
         exit 1
     fi


### PR DESCRIPTION
## Why this should be merged
Updates the integration tests to use a stable tagged release of `ava-labs/foundry` instead of the volatile nightly releases from `foundry-rs/foundry`