### PR TITLE
Add utility function for parsing generic logs

### DIFF
--- a/tests/basic_one_way_send.go
+++ b/tests/basic_one_way_send.go
@@ -50,7 +50,7 @@ func BasicOneWaySend() {
 
 	bind, err := teleportermessenger.NewTeleporterMessenger(teleporterContractAddress, subnetAInfo.ChainWSClient)
 	Expect(err).Should(BeNil())
-	event, err := utils.GetSendEventFromLogs(receipt.Logs, bind)
+	event, err := utils.GetEventFromLogs(receipt.Logs, bind.ParseSendCrossChainMessage)
 	Expect(err).Should(BeNil())
 	Expect(event.DestinationChainID[:]).Should(Equal(subnetBInfo.BlockchainID[:]))
 

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -8,7 +8,6 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -276,32 +277,21 @@ func RelayMessage(
 	bind, err := teleportermessenger.NewTeleporterMessenger(teleporterContractAddress, source.ChainWSClient)
 	Expect(err).Should(BeNil())
 	// Check the transaction logs for the ReceiveCrossChainMessage event emitted by the Teleporter contract
-	event, err := GetReceiveEventFromLogs(receipt.Logs, bind)
+	event, err := GetEventFromLogs(receipt.Logs, bind.ParseReceiveCrossChainMessage)
 	Expect(err).Should(BeNil())
 	Expect(event.OriginChainID[:]).Should(Equal(source.BlockchainID[:]))
 	return nil
 }
 
-func GetReceiveEventFromLogs(logs []*types.Log, bind *teleportermessenger.TeleporterMessenger) (*teleportermessenger.TeleporterMessengerReceiveCrossChainMessage, error) {
+// Returns the first log in 'logs' that is successfully parsed by 'parser'
+func GetEventFromLogs[T any](logs []*types.Log, parser func(log types.Log) (T, error)) (T, error) {
 	for _, log := range logs {
-		event, err := bind.ParseReceiveCrossChainMessage(*log)
+		event, err := parser(*log)
 		if err == nil {
 			return event, nil
-
 		}
 	}
-	return nil, fmt.Errorf("failed to find ReceiveCrossChainMessage event in receipt logs")
-}
-
-func GetSendEventFromLogs(logs []*types.Log, bind *teleportermessenger.TeleporterMessenger) (*teleportermessenger.TeleporterMessengerSendCrossChainMessage, error) {
-	for _, log := range logs {
-		event, err := bind.ParseSendCrossChainMessage(*log)
-		if err == nil {
-			return event, nil
-
-		}
-	}
-	return nil, fmt.Errorf("failed to find SendCrossChainMessage event in receipt logs")
+	return *new(T), fmt.Errorf("failed to find %T event in receipt logs", *new(T))
 }
 
 //


### PR DESCRIPTION
## Why this should be merged
Eliminates code duplication. Makes it very easy to parse logs from contracts.

## How this works

## How this was tested
Existing E2E tests that use this

## How is this documented