### PR TITLE
Set all containers to exit if one exits early

### DIFF
--- a/scripts/local/run.sh
+++ b/scripts/local/run.sh
@@ -48,7 +48,7 @@ setARCH
 
 if [ -z "$LOCAL_RELAYER_IMAGE" ]; then
     echo "Using published awm-relayer image"
-    docker compose -f docker/docker-compose-run.yml --project-directory ./ up --build &
+    docker compose -f docker/docker-compose-run.yml --project-directory ./ up --abort-on-container-exit --build &
 else
     echo "Using local awm-relayer image: $LOCAL_RELAYER_IMAGE"
     if [[ "$(docker images -q awm-relayer:$LOCAL_RELAYER_IMAGE 2> /dev/null)" == "" ]]; then
@@ -57,7 +57,7 @@ else
     fi
     rm -f docker/docker-compose-run-local.yml
     sed "s/<TAG>/$LOCAL_RELAYER_IMAGE/g" docker/docker-compose-run-local-template.yml > docker/docker-compose-run-local.yml
-    docker compose -f docker/docker-compose-run-local.yml --project-directory ./ up --build &
+    docker compose -f docker/docker-compose-run-local.yml --project-directory ./ up --abort-on-container-exit --build &
 fi
 
 tail -f /dev/null

--- a/scripts/local/test.sh
+++ b/scripts/local/test.sh
@@ -52,7 +52,7 @@ setARCH
 
 if [ -z "$LOCAL_RELAYER_IMAGE" ]; then
     echo "Using published awm-relayer image"
-    docker compose -f docker/docker-compose-test.yml --project-directory ./ up --build &
+    docker compose -f docker/docker-compose-test.yml --project-directory ./ up --abort-on-container-exit --build &
     dockerPid=$!
 else
     echo "Using local awm-relayer image: $LOCAL_RELAYER_IMAGE"
@@ -62,7 +62,7 @@ else
     fi
     rm -f docker/docker-compose-test-local.yml
     sed "s/<TAG>/$LOCAL_RELAYER_IMAGE/g" docker/docker-compose-test-local-template.yml > docker/docker-compose-test-local.yml
-    docker compose -f docker/docker-compose-test-local.yml --project-directory ./ up --build &
+    docker compose -f docker/docker-compose-test-local.yml --project-directory ./ up --abort-on-container-exit --build &
     dockerPid=$!
 fi
 


### PR DESCRIPTION
## Why this should be merged
Causes all docker containers to exit if one exits. This makes tracking down errors much easier.

## How this works

## How this was tested
Put `exit 1` at the start of `run_setup.sh`, then run `./scripts/local/test.sh` and watch all containers exit when `run_setup.sh` fails.

## How is this documented