### PR TITLE
Update relayer to v0.2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,76 +1,76 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - "*"
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - "*"
 
 env:
-  RELAYER_VERSION: v0.2.3
+    RELAYER_VERSION: v0.2.4
 
 jobs:
-  teleporter-integration-test:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 30
-    env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-    steps:
-      - name: Checkout repositories and submodules
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Download awm-relayer image
-        run: |
-          docker pull avaplatform/awm-relayer:${RELAYER_VERSION}
-
-      - name: Teleporter Integration Tests
-        run: |
-          ./scripts/local/test.sh
-
-      - name: Run Snyk on Docker image
-        # Dependabot isn't allowed to use the Snyk token, so skip this step.
-        if: ${{ ! startsWith(env.BRANCH_NAME, 'dependabot') }}
-        # TODO: Once we address the sarif upload issue below, we can re-enable
-        # continue-on-error to then upload the results to github.
-        # Snyk can be used to break the build when it detects vulnerabilities.
-        # In this case we want to upload the issues to GitHub Code Scanning
-        # continue-on-error: true
-        uses: snyk/actions/docker@master
+    teleporter-integration-test:
+        runs-on: ubuntu-20.04
+        timeout-minutes: 30
         env:
-          # In order to use the Snyk Action you will need to have a Snyk API token.
-          # More details in https://github.com/snyk/actions#getting-your-snyk-token
-          # or you can signup for free at https://snyk.io/login
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: local-network-image
-          args: --file=docker/Dockerfile --severity-threshold=high
+            BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        steps:
+            - name: Checkout repositories and submodules
+              uses: actions/checkout@v4
+              with:
+                  submodules: recursive
 
-    # TODO: Investigate how to limit the snyk.sarif file to only have a maximum of 20 "runs" so the upload succeeds here.
-    # See: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#validating-your-sarif-file
-    # - name: Upload results to GitHub Code Scanning
-    #   uses: github/codeql-action/upload-sarif@v2
-    #   with:
-    #     sarif_file: snyk.sarif
+            - name: Download awm-relayer image
+              run: |
+                  docker pull avaplatform/awm-relayer:${RELAYER_VERSION}
 
-  solidity-unit-tests:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    steps:
-      - name: Checkout repository and submodules
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+            - name: Teleporter Integration Tests
+              run: |
+                  ./scripts/local/test.sh
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+            - name: Run Snyk on Docker image
+              # Dependabot isn't allowed to use the Snyk token, so skip this step.
+              if: ${{ ! startsWith(env.BRANCH_NAME, 'dependabot') }}
+              # TODO: Once we address the sarif upload issue below, we can re-enable
+              # continue-on-error to then upload the results to github.
+              # Snyk can be used to break the build when it detects vulnerabilities.
+              # In this case we want to upload the issues to GitHub Code Scanning
+              # continue-on-error: true
+              uses: snyk/actions/docker@master
+              env:
+                  # In order to use the Snyk Action you will need to have a Snyk API token.
+                  # More details in https://github.com/snyk/actions#getting-your-snyk-token
+                  # or you can signup for free at https://snyk.io/login
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+              with:
+                  image: local-network-image
+                  args: --file=docker/Dockerfile --severity-threshold=high
 
-      - name: Run unit tests
-        run: |
-          cd contracts/
-          forge test -vvv
+        # TODO: Investigate how to limit the snyk.sarif file to only have a maximum of 20 "runs" so the upload succeeds here.
+        # See: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#validating-your-sarif-file
+        # - name: Upload results to GitHub Code Scanning
+        #   uses: github/codeql-action/upload-sarif@v2
+        #   with:
+        #     sarif_file: snyk.sarif
+
+    solidity-unit-tests:
+        runs-on: ubuntu-20.04
+        timeout-minutes: 10
+        steps:
+            - name: Checkout repository and submodules
+              uses: actions/checkout@v4
+              with:
+                  submodules: recursive
+
+            - name: Install Foundry
+              uses: foundry-rs/foundry-toolchain@v1
+              with:
+                  version: nightly
+
+            - name: Run unit tests
+              run: |
+                  cd contracts/
+                  forge test -vvv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,76 +1,76 @@
 name: Test
 
 on:
-    push:
-        branches:
-            - main
-    pull_request:
-        branches:
-            - "*"
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
 
 env:
-    RELAYER_VERSION: v0.2.4
+  RELAYER_VERSION: v0.2.4
 
 jobs:
-    teleporter-integration-test:
-        runs-on: ubuntu-20.04
-        timeout-minutes: 30
+  teleporter-integration-test:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+    steps:
+      - name: Checkout repositories and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download awm-relayer image
+        run: |
+          docker pull avaplatform/awm-relayer:${RELAYER_VERSION}
+
+      - name: Teleporter Integration Tests
+        run: |
+          ./scripts/local/test.sh
+
+      - name: Run Snyk on Docker image
+        # Dependabot isn't allowed to use the Snyk token, so skip this step.
+        if: ${{ ! startsWith(env.BRANCH_NAME, 'dependabot') }}
+        # TODO: Once we address the sarif upload issue below, we can re-enable
+        # continue-on-error to then upload the results to github.
+        # Snyk can be used to break the build when it detects vulnerabilities.
+        # In this case we want to upload the issues to GitHub Code Scanning
+        # continue-on-error: true
+        uses: snyk/actions/docker@master
         env:
-            BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        steps:
-            - name: Checkout repositories and submodules
-              uses: actions/checkout@v4
-              with:
-                  submodules: recursive
+          # In order to use the Snyk Action you will need to have a Snyk API token.
+          # More details in https://github.com/snyk/actions#getting-your-snyk-token
+          # or you can signup for free at https://snyk.io/login
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: local-network-image
+          args: --file=docker/Dockerfile --severity-threshold=high
 
-            - name: Download awm-relayer image
-              run: |
-                  docker pull avaplatform/awm-relayer:${RELAYER_VERSION}
+    # TODO: Investigate how to limit the snyk.sarif file to only have a maximum of 20 "runs" so the upload succeeds here.
+    # See: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#validating-your-sarif-file
+    # - name: Upload results to GitHub Code Scanning
+    #   uses: github/codeql-action/upload-sarif@v2
+    #   with:
+    #     sarif_file: snyk.sarif
 
-            - name: Teleporter Integration Tests
-              run: |
-                  ./scripts/local/test.sh
+  solidity-unit-tests:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-            - name: Run Snyk on Docker image
-              # Dependabot isn't allowed to use the Snyk token, so skip this step.
-              if: ${{ ! startsWith(env.BRANCH_NAME, 'dependabot') }}
-              # TODO: Once we address the sarif upload issue below, we can re-enable
-              # continue-on-error to then upload the results to github.
-              # Snyk can be used to break the build when it detects vulnerabilities.
-              # In this case we want to upload the issues to GitHub Code Scanning
-              # continue-on-error: true
-              uses: snyk/actions/docker@master
-              env:
-                  # In order to use the Snyk Action you will need to have a Snyk API token.
-                  # More details in https://github.com/snyk/actions#getting-your-snyk-token
-                  # or you can signup for free at https://snyk.io/login
-                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-              with:
-                  image: local-network-image
-                  args: --file=docker/Dockerfile --severity-threshold=high
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
 
-        # TODO: Investigate how to limit the snyk.sarif file to only have a maximum of 20 "runs" so the upload succeeds here.
-        # See: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#validating-your-sarif-file
-        # - name: Upload results to GitHub Code Scanning
-        #   uses: github/codeql-action/upload-sarif@v2
-        #   with:
-        #     sarif_file: snyk.sarif
-
-    solidity-unit-tests:
-        runs-on: ubuntu-20.04
-        timeout-minutes: 10
-        steps:
-            - name: Checkout repository and submodules
-              uses: actions/checkout@v4
-              with:
-                  submodules: recursive
-
-            - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
-              with:
-                  version: nightly
-
-            - name: Run unit tests
-              run: |
-                  cd contracts/
-                  forge test -vvv
+      - name: Run unit tests
+        run: |
+          cd contracts/
+          forge test -vvv

--- a/docker/docker-compose-run.yml
+++ b/docker/docker-compose-run.yml
@@ -3,30 +3,30 @@
 
 version: "3.9"
 services:
-    local_network:
-        build:
-            context: ./
-            dockerfile: ./docker/Dockerfile
-            args:
-                ARCH: ${ARCH} # set by run.sh
-        container_name: local_network_run
-        init: true
-        working_dir: /code
-        entrypoint: ["/code/docker/run_setup.sh"]
-        network_mode: "host"
-        volumes:
-            - type: bind
-              source: ./
-              target: /code/
-    relayer:
-        image: avaplatform/awm-relayer:v0.2.4
-        container_name: relayer_run
-        init: true
-        working_dir: /code
-        entrypoint: /code/docker/run_relayer.sh
-        network_mode: "host"
-        user: "root"
-        volumes:
-            - type: bind
-              source: ./
-              target: /code/
+  local_network:
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile
+      args:
+        ARCH: ${ARCH} # set by run.sh
+    container_name: local_network_run
+    init: true
+    working_dir: /code
+    entrypoint: ["/code/docker/run_setup.sh"]
+    network_mode: "host"
+    volumes:
+      - type: bind
+        source: ./
+        target: /code/
+  relayer:
+    image: avaplatform/awm-relayer:v0.2.4
+    container_name: relayer_run
+    init: true
+    working_dir: /code
+    entrypoint: /code/docker/run_relayer.sh
+    network_mode: "host"
+    user: "root"
+    volumes:
+      - type: bind
+        source: ./
+        target: /code/

--- a/docker/docker-compose-run.yml
+++ b/docker/docker-compose-run.yml
@@ -3,30 +3,30 @@
 
 version: "3.9"
 services:
-  local_network:
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile
-      args:
-        ARCH: ${ARCH} # set by run.sh
-    container_name: local_network_run
-    init: true
-    working_dir: /code
-    entrypoint: ["/code/docker/run_setup.sh"]
-    network_mode: "host"
-    volumes:
-      - type: bind
-        source: ./
-        target: /code/
-  relayer:
-    image: avaplatform/awm-relayer:v0.2.3
-    container_name: relayer_run
-    init: true
-    working_dir: /code
-    entrypoint: /code/docker/run_relayer.sh
-    network_mode: "host"
-    user: "root"
-    volumes:
-      - type: bind
-        source: ./
-        target: /code/
+    local_network:
+        build:
+            context: ./
+            dockerfile: ./docker/Dockerfile
+            args:
+                ARCH: ${ARCH} # set by run.sh
+        container_name: local_network_run
+        init: true
+        working_dir: /code
+        entrypoint: ["/code/docker/run_setup.sh"]
+        network_mode: "host"
+        volumes:
+            - type: bind
+              source: ./
+              target: /code/
+    relayer:
+        image: avaplatform/awm-relayer:v0.2.4
+        container_name: relayer_run
+        init: true
+        working_dir: /code
+        entrypoint: /code/docker/run_relayer.sh
+        network_mode: "host"
+        user: "root"
+        volumes:
+            - type: bind
+              source: ./
+              target: /code/

--- a/docker/docker-compose-test.yml
+++ b/docker/docker-compose-test.yml
@@ -3,48 +3,48 @@
 
 version: "3.9"
 services:
-    local_network:
-        image: local-network-image
-        build:
-            context: ./
-            dockerfile: ./docker/Dockerfile
-            args:
-                ARCH: ${ARCH} # set by test.sh
-        container_name: local_network_test
-        init: true
-        working_dir: /code
-        entrypoint: ["/code/docker/run_setup.sh"]
-        network_mode: "host"
-        volumes:
-            - type: bind
-              source: ./
-              target: /code/
-    relayer:
-        image: avaplatform/awm-relayer:v0.2.4
-        init: true
-        working_dir: /code
-        entrypoint: /code/docker/run_relayer.sh
-        network_mode: "host"
-        user: "root"
-        volumes:
-            - type: bind
-              source: ./
-              target: /code/
-    test_runner:
-        image: test-runner-image
-        build:
-            context: ./
-            dockerfile: ./docker/Dockerfile
-            args:
-                ARCH: ${ARCH} # set by test.sh
-        container_name: test_runner
-        init: true
-        working_dir: /code
-        entrypoint: /code/docker/run_tests.sh
-        network_mode: "host"
-        volumes:
-            - type: bind
-              source: ./
-              target: /code/
-        environment:
-            - TEST_TARGET=${TEST_TARGET}
+  local_network:
+    image: local-network-image
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile
+      args:
+        ARCH: ${ARCH} # set by test.sh
+    container_name: local_network_test
+    init: true
+    working_dir: /code
+    entrypoint: ["/code/docker/run_setup.sh"]
+    network_mode: "host"
+    volumes:
+      - type: bind
+        source: ./
+        target: /code/
+  relayer:
+    image: avaplatform/awm-relayer:v0.2.4
+    init: true
+    working_dir: /code
+    entrypoint: /code/docker/run_relayer.sh
+    network_mode: "host"
+    user: "root"
+    volumes:
+      - type: bind
+        source: ./
+        target: /code/
+  test_runner:
+    image: test-runner-image
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile
+      args:
+        ARCH: ${ARCH} # set by test.sh
+    container_name: test_runner
+    init: true
+    working_dir: /code
+    entrypoint: /code/docker/run_tests.sh
+    network_mode: "host"
+    volumes:
+      - type: bind
+        source: ./
+        target: /code/
+    environment:
+      - TEST_TARGET=${TEST_TARGET}

--- a/docker/docker-compose-test.yml
+++ b/docker/docker-compose-test.yml
@@ -3,48 +3,48 @@
 
 version: "3.9"
 services:
-  local_network:
-    image: local-network-image
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile
-      args:
-        ARCH: ${ARCH} # set by test.sh
-    container_name: local_network_test
-    init: true
-    working_dir: /code
-    entrypoint: ["/code/docker/run_setup.sh"]
-    network_mode: "host"
-    volumes:
-      - type: bind
-        source: ./
-        target: /code/
-  relayer:
-    image: avaplatform/awm-relayer:v0.2.3
-    init: true
-    working_dir: /code
-    entrypoint: /code/docker/run_relayer.sh
-    network_mode: "host"
-    user: "root"
-    volumes:
-      - type: bind
-        source: ./
-        target: /code/
-  test_runner:
-    image: test-runner-image
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile
-      args:
-        ARCH: ${ARCH} # set by test.sh
-    container_name: test_runner
-    init: true
-    working_dir: /code
-    entrypoint: /code/docker/run_tests.sh
-    network_mode: "host"
-    volumes:
-      - type: bind
-        source: ./
-        target: /code/
-    environment:
-      - TEST_TARGET=${TEST_TARGET}
+    local_network:
+        image: local-network-image
+        build:
+            context: ./
+            dockerfile: ./docker/Dockerfile
+            args:
+                ARCH: ${ARCH} # set by test.sh
+        container_name: local_network_test
+        init: true
+        working_dir: /code
+        entrypoint: ["/code/docker/run_setup.sh"]
+        network_mode: "host"
+        volumes:
+            - type: bind
+              source: ./
+              target: /code/
+    relayer:
+        image: avaplatform/awm-relayer:v0.2.4
+        init: true
+        working_dir: /code
+        entrypoint: /code/docker/run_relayer.sh
+        network_mode: "host"
+        user: "root"
+        volumes:
+            - type: bind
+              source: ./
+              target: /code/
+    test_runner:
+        image: test-runner-image
+        build:
+            context: ./
+            dockerfile: ./docker/Dockerfile
+            args:
+                ARCH: ${ARCH} # set by test.sh
+        container_name: test_runner
+        init: true
+        working_dir: /code
+        entrypoint: /code/docker/run_tests.sh
+        network_mode: "host"
+        volumes:
+            - type: bind
+              source: ./
+              target: /code/
+        environment:
+            - TEST_TARGET=${TEST_TARGET}

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -3,7 +3,7 @@
 # See the file LICENSE for licensing terms.
 
 # Set up the versions to be used
-AWM_RELAYER_VERSION=${AWM_RELAYER_VERSION:-'v0.2.3'}
+AWM_RELAYER_VERSION=${AWM_RELAYER_VERSION:-'v0.2.4'}
 SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.5.8'}
 # Don't export them as they're used in the context of other calls
 AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.10.14'}


### PR DESCRIPTION
## Why this should be merged
Updates relayer version to v0.2.4 which is compatible with subnet-evm v0.5.9.

## How this works

## How this was tested
CI

## How is this documented