### PR TITLE
Add JSX Closing tag for Dev Docs

### DIFF
--- a/contracts/src/Teleporter/README.md
+++ b/contracts/src/Teleporter/README.md
@@ -21,7 +21,7 @@ The `ITeleporterReceiver` interface provides a single method. All contracts that
 
 ## Data Flow
 <div align="center">
-  <img src="../../../resources/TeleporterDataFlowDiagram.png?raw=true">
+  <img src="../../../resources/TeleporterDataFlowDiagram.png?raw=true"/>
 </div>
 
 ## Properties


### PR DESCRIPTION
## Why this should be merged

The lack of a closing tag is causing the [Avalanche-docs](https://github.com/ava-labs/avalanche-docs/pull/1554) build to break. Adding this will enable a plugin in our docs repo to pull docs directly from the Teleporter repo.

## How this works

One line fix. added a `/` to the `<img>`