### PR TITLE
have Ginkgo always emit the full stack trace

### DIFF
--- a/scripts/local/e2e_test.sh
+++ b/scripts/local/e2e_test.sh
@@ -79,7 +79,8 @@ ginkgo build ./tests/
 echo "Running e2e tests $RUN_E2E"
 RUN_E2E=true ./tests/tests.test \
   --ginkgo.vv \
-  --ginkgo.label-filter=${GINKGO_LABEL_FILTER:-""}
+  --ginkgo.label-filter=${GINKGO_LABEL_FILTER:-""} \
+  --ginkgo.trace
 
 echo "e2e tests passed"
 exit 0


### PR DESCRIPTION
## Why this should be merged

It's pretty annoying how you don't get a call stack when a test fails in a function outside of the test module, because you can't tell what part of your test case the failure actually came from. And that seems to happen quite a bit, at least in my recent work. (tons of verification does happen in the `utils` module.)

## How this works
                                                                                                                                                                                                                                          
The same failure is depicted below before and after this change.                                                                                                                                                                           
                                                                                                                                                                                                                                           
Before:                                                                                                                                                                                                                                    
```                                                                                                                                                                                                                                        
  [FAILED] Expected                                                                                                                                                                                                                        
      <*rpc.jsonError | 0xc002b0ba10>:                                                                                                                                                                                                     
      execution reverted                                                                                                                                                                                                                   
      {                                                                                                                                                                                                                                    
          Code: -32000,                                                                                                                                                                                                                    
          Message: "execution reverted",                                                                                                                                                                                                   
          Data: nil,                                                                                                                                                                                                                       
      }                                                                                                                                                                                                                                    
  to be nil                                                                                                                                                                                                                                
  In [It] at: /home/gene/dev/teleporter/tests/utils/utils.go:96 @ 11/22/23 15:42:22.261                                                                                                                                                    
  < Exit [It] Send a message from Subnet A to Subnet B, and one from B to A - /home/gene/dev/teleporter/tests/e2e_test.go:58 @ 11/22/23 15:42:22.261 (6.075s)                                                                              
• [FAILED] [6.075 seconds]                                                                                                                                                                                                                 
[Teleporter integration tests]                                                                                                                                                                                                             
/home/gene/dev/teleporter/tests/e2e_test.go:52                                                                                                                                                                                             
  [It] Send a message from Subnet A to Subnet B, and one from B to A                                                                                                                                                                       
  /home/gene/dev/teleporter/tests/e2e_test.go:58                                                                                                                                                                                           
```                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                           
After:                                                                                                                                                                                                                                     
```                                                                                                                                                                                                                                        
  [FAILED] Expected                                                                                                                                                                                                                        
      <*rpc.jsonError | 0xc0030805a0>:                                                                                                                                                                                                     
      execution reverted                                                                                                                                                                                                                   
      {                                                                                                                                                                                                                                    
          Code: -32000,                                                                                                                                                                                                                    
          Message: "execution reverted",                                                                                                                                                                                                   
          Data: nil,                                                                                                                                                                                                                       
      }                                                                                                                                                                                                                                    
  to be nil                                                                                                                                                                                                                                
  In [It] at: /home/gene/dev/teleporter/tests/utils/utils.go:96 @ 11/22/23 15:49:02.26                                                                                                                                                     
                                                                                                                                                                                                                                           
  Full Stack Trace                                                                                                                                                                                                                         
    github.com/ava-labs/teleporter/tests/utils.SendCrossChainMessageAndWaitForAcceptance({_, _}, {{0xbc, 0x51, 0x19, 0xd5, 0x89, 0x4d, 0x58, 0x53, ...}, ...}, ...)                                                                        
        /home/gene/dev/teleporter/tests/utils/utils.go:96 +0x163                                                                                                                                                                           
    github.com/ava-labs/teleporter/tests.BasicSendReceive({0x1d907d0, 0x38e1440})                                                                                                                                                          
        /home/gene/dev/teleporter/tests/basic_send_receive.go:95 +0x79d                                                                                                                                                                    
    github.com/ava-labs/teleporter/tests.BasicSendReceiveGinkgo()                                                                                                                                                                          
        /home/gene/dev/teleporter/tests/basic_send_receive.go:17 +0x25                                                                                                                                                                     
  < Exit [It] Send a message from Subnet A to Subnet B, and one from B to A - /home/gene/dev/teleporter/tests/e2e_test.go:58 @ 11/22/23 15:49:02.26 (6.066s)                                                                               
• [FAILED] [6.066 seconds]                                                                                                                                                                                                                 
[Teleporter integration tests]                                                                                                                                                                                                             
/home/gene/dev/teleporter/tests/e2e_test.go:52                                                                                                                                                                                             
  [It] Send a message from Subnet A to Subnet B, and one from B to A                                                                                                                                                                       
  /home/gene/dev/teleporter/tests/e2e_test.go:58                                                                                                                                                                                           
```

## How this was tested

By running the tests

## How is this documented

https://onsi.github.io/ginkgo/#other-settings