### PR TITLE
Use pinned version of Foundry for CI

### DIFF
--- a/.github/workflows/abi_bindings_checker.yml
+++ b/.github/workflows/abi_bindings_checker.yml
@@ -31,9 +31,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+        run: ./scripts/install_foundry.sh
 
       - name: Generate ABI Go bindings
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,9 +43,7 @@ jobs:
           ./scripts/build.sh /tmp/e2e-test/avalanchego/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+        run: ./scripts/install_foundry.sh
 
       - name: Run E2E Tests
         # Forge installs to BASE_DIR, but updates the PATH definition in $HOME/.bashrc

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -32,9 +32,7 @@ jobs:
           pip install slither-analyzer
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+        run: ./scripts/install_foundry.sh
 
       - name: Run Slither
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,9 +64,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+        run: ./scripts/install_foundry.sh
 
       - name: Run unit tests
         run: |

--- a/scripts/install_foundry.sh
+++ b/scripts/install_foundry.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -e
+
+FOUNDRY_VERSION=v0.1.0
+curl -L https://raw.githubusercontent.com/ava-labs/foundry/${FOUNDRY_VERSION}/foundryup/install > ~/tmp/foundry-install-script
+sed -i "s/\/ava-labs\/foundry\/master\/foundryup/\/ava-labs\/foundry\/${FOUNDRY_VERSION}\/foundryup/g" ~/tmp/foundry-install-script
+cat ~/tmp/foundry-install-script | bash
+echo "export PATH=\"$PATH:/$HOME/.foundry/bin\"">> ~/.bashrc
+source ~/.bashrc
+export PATH=$PATH:$HOME/.foundry/bin:$HOME/.cargo/bin
+foundryup --version ${FOUNDRY_VERSION}


### PR DESCRIPTION
## Why this should be merged
Uses same foundry version for all CI jobs.

## How this works
We were previously using the pinned version for integration tests, but nightly for everything else.

## How this was tested

## How is this documented