### PR TITLE
Ignore forge bin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 out/
 cache/
 target/
+bin/
 Cargo.lock
 
 # IDE configurations


### PR DESCRIPTION
## Why this should be merged
We added the step of creating the bin files, but we should gitignore them along with the other generated files.

## How this works

## How this was tested

## How is this documented