### PR TITLE
Fix tmp installation directory used in local e2e script

### DIFF
--- a/scripts/local/e2e_test.sh
+++ b/scripts/local/e2e_test.sh
@@ -12,7 +12,7 @@ TELEPORTER_PATH=$(
 source "$TELEPORTER_PATH"/scripts/constants.sh
 source "$TELEPORTER_PATH"/scripts/versions.sh
 
-BASEDIR=${BASEDIR:-"~/tmp/e2e-test"}
+BASEDIR=${BASEDIR:-"/tmp/e2e-test"}
 
 cwd=$(pwd)
 # Install the avalanchego and subnet-evm binaries

--- a/scripts/local/e2e_test.sh
+++ b/scripts/local/e2e_test.sh
@@ -12,7 +12,7 @@ TELEPORTER_PATH=$(
 source "$TELEPORTER_PATH"/scripts/constants.sh
 source "$TELEPORTER_PATH"/scripts/versions.sh
 
-BASEDIR=${BASEDIR:-"/tmp/e2e-test"}
+BASEDIR=${BASEDIR:-"$HOME/.teleporter-deps"}
 
 cwd=$(pwd)
 # Install the avalanchego and subnet-evm binaries


### PR DESCRIPTION
## Why this should be merged

In `e2e_test.sh`, `BASEDIR` is currently set as `BASEDIR=${BASEDIR:-"~/tmp/e2e-test"}`, but expansion of ~ to the home directory does not occur when the path is inside of double quotes. As a result, the binaries installed are put under `teleporter/~/...`, if the script is run from the base of the repo.

Instead, the installation will be put under `$HOME/.teleporter-deps`, since persisting them will allow subsequent runs to skip the installation step.

## How this works

Removes "~" inside of the setting of `BASEDIR`. Instead uses the `$HOME/.teleporter-deps`.

## How this was tested

Running `./scripts/local/e2e_test.sh`

## How is this documented

N/A