### PR TITLE
Properly set go version in workflows

### DIFF
--- a/.github/workflows/abi_bindings_checker.yml
+++ b/.github/workflows/abi_bindings_checker.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/gomod_checker.yml
+++ b/.github/workflows/gomod_checker.yml
@@ -20,7 +20,7 @@ jobs:
 
       - run: |
           source ./scripts/versions.sh
-          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set Go version
       run: |
         source ./scripts/versions.sh
-        GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+        echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
     - name: Setup Go
       uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -63,7 +63,7 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## Why this should be merged
`GO_VERSION=$GO_VERSION >> $GITHUB_ENV` is not a proper bash command, so was failing, but silently for some reason. This was causing the env var not to be set, so the `go-version` in `actions/setup-go@v5` was defaulting to `1.20.11`

## How this works

## How this was tested

## How is this documented