### PR TITLE
Fix example scripts

### DIFF
--- a/scripts/local/examples/basic_send_receive.sh
+++ b/scripts/local/examples/basic_send_receive.sh
@@ -26,8 +26,8 @@ set -e # Stop on first error
 # Deploy a test ERC20 to be used in the E2E test.
 cd contracts
 erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $c_chain_rpc_url)
-erc20_contract_address_a=$(parseContractAddress "$erc20_deploy_result")
-echo "Test ERC20 contract deployed to $erc20_contract_address_a on subnet A"
+erc20_contract_address_c_chain=$(parseContractAddress "$erc20_deploy_result")
+echo "Test ERC20 contract deployed to $erc20_contract_address_c_chain on the C-Chain"
 erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $subnet_a_rpc_url)
 erc20_contract_address_a=$(parseContractAddress "$erc20_deploy_result")
 echo "Test ERC20 contract deployed to $erc20_contract_address_a on subnet A"
@@ -53,10 +53,11 @@ send_cross_subnet_message_message_data=cafebabecafebabecafebabecafebabecafebabec
 
 # Approve the Teleporter contract to some ERC20 tokens from the user account we're using to send transactions
 approve_amount=100000000000000000000000000000
-cast send $erc20_contract_address_a "approve(address,uint256)(bool)" $teleporter_contract_address \
+cast send $erc20_contract_address_c_chain "approve(address,uint256)(bool)" $teleporter_contract_address \
     $approve_amount \
     --private-key $user_private_key --rpc-url $c_chain_rpc_url
-result=$(cast call $erc20_contract_address_a "allowance(address,address)(uint256)" $user_address $teleporter_contract_address --rpc-url $c_chain_rpc_url)
+result=$(cast call $erc20_contract_address_c_chain "allowance(address,address)(uint256)" $user_address $teleporter_contract_address --rpc-url $c_chain_rpc_url)
+result=$(echo $result | cut -d' ' -f1)
 if [[ $result -ne $approve_amount ]]; then
     echo $result
     echo $approve_amount
@@ -66,10 +67,10 @@ fi
 
 echo "Approved the Teleporter contract to spend the test ERC20 token from the user account."
 
-startID=$(cast call $teleporter_contract_address "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(uint256)" "($send_cross_subnet_message_destination_chain_id,$send_cross_subnet_message_destination_address,($erc20_contract_address_a,$send_cross_subnet_message_fee_amount),$send_cross_subnet_message_required_gas_limit,[],$send_cross_subnet_message_message_data)" --from $user_address --rpc-url $c_chain_rpc_url)
+startID=$(cast call $teleporter_contract_address "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(uint256)" "($send_cross_subnet_message_destination_chain_id,$send_cross_subnet_message_destination_address,($erc20_contract_address_c_chain,$send_cross_subnet_message_fee_amount),$send_cross_subnet_message_required_gas_limit,[],$send_cross_subnet_message_message_data)" --from $user_address --rpc-url $c_chain_rpc_url)
 echo "Got starting ID $startID to teleport address $teleporter_contract_address"
 echo "Got Ids $c_chain_blockchain_id_hex $subnet_a_blockchain_id_hex $c_chain_subnet_id $subnet_a_subnet_id"
-cast send $teleporter_contract_address "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(uint256)" "($send_cross_subnet_message_destination_chain_id,$send_cross_subnet_message_destination_address,($erc20_contract_address_a,$send_cross_subnet_message_fee_amount),$send_cross_subnet_message_required_gas_limit,[],$send_cross_subnet_message_message_data)" --private-key $user_private_key --rpc-url $c_chain_rpc_url
+cast send $teleporter_contract_address "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(uint256)" "($send_cross_subnet_message_destination_chain_id,$send_cross_subnet_message_destination_address,($erc20_contract_address_c_chain,$send_cross_subnet_message_fee_amount),$send_cross_subnet_message_required_gas_limit,[],$send_cross_subnet_message_message_data)" --private-key $user_private_key --rpc-url $c_chain_rpc_url
 
 retry_count=0
 received=$(cast call $teleporter_contract_address "messageReceived(bytes32,uint256)(bool)" $c_chain_blockchain_id_hex $startID --rpc-url $subnet_a_rpc_url)
@@ -109,6 +110,7 @@ send_cross_subnet_message_message_data=cafebabecafebabecafebabecafebabecafebabec
 # Approve the teleporter contract to some ERC20 tokens from the user account we're using to send transactions
 cast send $erc20_contract_address_a "approve(address,uint256)(bool)" $teleporter_contract_address $approve_amount --private-key $user_private_key --rpc-url $subnet_a_rpc_url
 result=$(cast call $erc20_contract_address_a "allowance(address,address)(uint256)" $user_address $teleporter_contract_address --rpc-url $subnet_a_rpc_url)
+result=$(echo $result | cut -d' ' -f1)
 if [[ $result -ne $approve_amount ]]; then
     echo $result
     echo "Error approving Teleporter contract to spend ERC20 from user account."

--- a/utils/contract-deployment/README.md
+++ b/utils/contract-deployment/README.md
@@ -24,7 +24,7 @@ Now that the keyless transaction is constructed, fund the deployer address. For 
 
 ```bash
 teleporter_deploy_address=$(cat UniversalTeleporterDeployerAddress.txt)
-cast send --private-key $my_private_key --value 50ether $teleporter_deploy_address --rpc-url $my_rpc_url
+cast send --private-key $my_private_key --value 10ether $teleporter_deploy_address --rpc-url $my_rpc_url
 ```
 
 Then, deploy Teleporter by sending the keyless transaction:

--- a/utils/contract-deployment/README.md
+++ b/utils/contract-deployment/README.md
@@ -18,3 +18,20 @@ OR
 
 ## Results
 The resulting raw transaction, `TeleporterMessenger` contract address, and universal deployer address are written to standard output, as well as to `UniversalTeleporterDeployerTransaction.txt`, `UniversalTeleporterMessengerContractAddress.txt`, and `UniversalTeleporterDeployerAddress.txt` respectively.
+
+## Deploy the contract
+Now that the keyless transaction is constructed, fund the deployer address. For example, using `cast`:
+
+```bash
+teleporter_deploy_tx=$(cat UniversalTeleporterDeployerTransaction.txt)
+cast send --private-key $my_private_key --value 50ether $teleporter_deploy_address --rpc-url $my_rpc_url
+```
+
+Then, deploy Teleporter by sending the keyless transaction:
+
+```bash
+teleporter_deploy_tx=$(cat UniversalTeleporterDeployerTransaction.txt)
+cast publish --rpc-url $my_rpc_url $teleporter_deploy_tx
+```
+
+Once you've verified that Teleporter was deployed to the address in `UniversalTeleporterMessengerContractAddress.txt`, Teleporter is ready to use.

--- a/utils/contract-deployment/README.md
+++ b/utils/contract-deployment/README.md
@@ -23,7 +23,7 @@ The resulting raw transaction, `TeleporterMessenger` contract address, and unive
 Now that the keyless transaction is constructed, fund the deployer address. For example, using `cast`:
 
 ```bash
-teleporter_deploy_tx=$(cat UniversalTeleporterDeployerTransaction.txt)
+teleporter_deploy_address=$(cat UniversalTeleporterDeployerAddress.txt)
 cast send --private-key $my_private_key --value 50ether $teleporter_deploy_address --rpc-url $my_rpc_url
 ```
 


### PR DESCRIPTION
## Why this should be merged
Fixes two bugs in the example scripts:
- `cast send` results return numerical values in the form `1000 [1e3]`. We need to strip the raw number before using it.
- Some C-Chain and Subnet A variables were overloaded.

This PR also expands the contract deployment README to include complete steps for deploying Teleporter, not just creating the keyless transaction params

## How this works
See above

## How this was tested
Ran run.sh

## How is this documented
Self explanatory