### PR TITLE
fix: display right contract addr in script

### DIFF
--- a/scripts/deploy_teleporter.sh
+++ b/scripts/deploy_teleporter.sh
@@ -76,7 +76,8 @@ echo "TeleporterMessenger $teleporter_version deployer address: $teleporter_depl
 teleporter_deploy_tx=$(curl -sL https://github.com/ava-labs/teleporter/releases/download/$teleporter_version/TeleporterMessenger_Deployment_Transaction_$teleporter_version.txt)
 
 # Check if this TeleporterMessenger version has already been deployed on this chain.
-if [[ $(cast code --rpc-url $rpc_url $teleporter_contract_address) != "0x" ]]; then
+teleporter_contract_code=$(cast code --rpc-url $rpc_url $teleporter_contract_address)
+if [[ $teleporter_contract_code != "0x" ]]; then
     echo "TeleporterMessenger $teleporter_version has already been deployed on this chain." && exit 0
 fi
 
@@ -85,7 +86,7 @@ deployer_balance=$(cast balance --rpc-url $rpc_url $teleporter_deployer_address)
 
 if [[ $(echo "$deployer_balance>=$gas_tokens_required" | bc) == 1 ]]; then
     echo "Deployer address already funded"
-else 
+else
     # Calculate how many wei the deployer address needs to create the contract.
     transfer_amount=$(echo "$gas_tokens_required-$deployer_balance" | bc)
     if [[ $user_private_key == "" ]]; then
@@ -98,5 +99,5 @@ fi
 echo "Deploying TeleporterMessenger $teleporter_version"
 cast publish --rpc-url $rpc_url $teleporter_deploy_tx
 
-echo "Success! TeleporterMessenger $teleporter_version deployed to $teleporter_deployer_address"
+echo "Success! TeleporterMessenger $teleporter_version deployed to $teleporter_contract_address"
 exit 0


### PR DESCRIPTION
## Why this should be merged

This PR brings minor fixes to the `deploy_teleporter.sh` script:
- Separating the `cast code` from the `if` statement allows for better error handling. For example, a 404 error will end up printing `TeleporterMessenger $teleporter_version has already been deployed on this chain.` (what is false)
- Display the right address in the final print

## How this works

N/A

## How this was tested

By deploying Teleporter to an EVM chain on a local network.

## How is this documented

N/A