### PR TITLE
Pause and unpause Teleporter e2e test

### DIFF
--- a/tests/flows/example_messenger.go
+++ b/tests/flows/example_messenger.go
@@ -17,8 +17,8 @@ func ExampleMessenger(network interfaces.Network) {
 	//
 	ctx := context.Background()
 
-	_, subnetAExampleMessenger := utils.DeployExampleCrossChainMessenger(ctx, fundedKey, subnetAInfo)
-	exampleMessengerContractB, subnetBExampleMessenger := utils.DeployExampleCrossChainMessenger(
+	_, exampleMessengerA := utils.DeployExampleCrossChainMessenger(ctx, fundedKey, subnetAInfo)
+	exampleMessengerAddressB, exampleMessengerB := utils.DeployExampleCrossChainMessenger(
 		ctx, fundedKey, subnetBInfo,
 	)
 
@@ -26,10 +26,10 @@ func ExampleMessenger(network interfaces.Network) {
 		ctx,
 		network,
 		subnetAInfo,
-		subnetAExampleMessenger,
+		exampleMessengerA,
 		subnetBInfo,
-		exampleMessengerContractB,
-		subnetBExampleMessenger,
+		exampleMessengerAddressB,
+		exampleMessengerB,
 		fundedKey,
 		"Hello World!",
 		true,

--- a/tests/flows/pause_teleporter.go
+++ b/tests/flows/pause_teleporter.go
@@ -1,0 +1,81 @@
+package flows
+
+import (
+	"context"
+
+	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
+	"github.com/ava-labs/teleporter/tests/interfaces"
+	"github.com/ava-labs/teleporter/tests/utils"
+	. "github.com/onsi/gomega"
+)
+
+func PauseTeleporter(network interfaces.Network) {
+	subnetAInfo := network.GetPrimaryNetworkInfo()
+	subnetBInfo, _ := utils.GetTwoSubnets(network)
+	_, fundedKey := network.GetFundedAccountInfo()
+
+	//
+	// Deploy ExampleMessenger to Subnets A and B
+	//
+	ctx := context.Background()
+	teleporterAddress := network.GetTeleporterContractAddress()
+	_, exampleMessengerA := utils.DeployExampleCrossChainMessenger(ctx, fundedKey, subnetAInfo)
+	exampleMessengerAddressB, exampleMessengerB := utils.DeployExampleCrossChainMessenger(
+		ctx, fundedKey, subnetBInfo,
+	)
+
+	// Pause Teleporter on subnet B
+	opts, err := bind.NewKeyedTransactorWithChainID(
+		fundedKey, subnetBInfo.EVMChainID)
+	Expect(err).Should(BeNil())
+	tx, err := exampleMessengerB.PauseTeleporterAddress(opts, teleporterAddress)
+	Expect(err).Should(BeNil())
+
+	receipt := utils.WaitForTransactionSuccess(ctx, subnetBInfo, tx)
+	pauseTeleporterEvent, err := utils.GetEventFromLogs(receipt.Logs, exampleMessengerB.ParseTeleporterAddressPaused)
+	Expect(err).Should(BeNil())
+	Expect(pauseTeleporterEvent.TeleporterAddress).Should(Equal(teleporterAddress))
+
+	isPaused, err := exampleMessengerB.IsTeleporterAddressPaused(&bind.CallOpts{}, teleporterAddress)
+	Expect(err).Should(BeNil())
+	Expect(isPaused).Should(BeTrue())
+
+	// Send a message from subnet A to subnet B, which should fail
+	utils.SendExampleCrossChainMessageAndVerify(
+		ctx,
+		network,
+		subnetAInfo,
+		exampleMessengerA,
+		subnetBInfo,
+		exampleMessengerAddressB,
+		exampleMessengerB,
+		fundedKey,
+		"message_1",
+		false)
+
+	// Unpause Teleporter on subnet B
+	tx, err = exampleMessengerB.UnpauseTeleporterAddress(opts, teleporterAddress)
+	Expect(err).Should(BeNil())
+
+	receipt = utils.WaitForTransactionSuccess(ctx, subnetBInfo, tx)
+	unpauseTeleporterEvent, err := utils.GetEventFromLogs(receipt.Logs, exampleMessengerB.ParseTeleporterAddressUnpaused)
+	Expect(err).Should(BeNil())
+	Expect(unpauseTeleporterEvent.TeleporterAddress).Should(Equal(teleporterAddress))
+
+	isPaused, err = exampleMessengerB.IsTeleporterAddressPaused(&bind.CallOpts{}, teleporterAddress)
+	Expect(err).Should(BeNil())
+	Expect(isPaused).Should(BeFalse())
+
+	// Send a message from subnet A to subnet B again, which should now succeed
+	utils.SendExampleCrossChainMessageAndVerify(
+		ctx,
+		network,
+		subnetAInfo,
+		exampleMessengerA,
+		subnetBInfo,
+		exampleMessengerAddressB,
+		exampleMessengerB,
+		fundedKey,
+		"message_2",
+		true)
+}

--- a/tests/local/e2e_test.go
+++ b/tests/local/e2e_test.go
@@ -112,6 +112,9 @@ var _ = ginkgo.Describe("[Teleporter integration tests]", func() {
 	ginkgo.It("Resubmit altered message", func() {
 		flows.ResubmitAlteredMessage(LocalNetworkInstance)
 	})
+	ginkgo.It("Pause and Unpause Teleporter", func() {
+		flows.PauseTeleporter(LocalNetworkInstance)
+	})
 
 	// The following tests require special behavior by the relayer, so we only run them on a local network
 	ginkgo.It("Relayer modifies message", func() {


### PR DESCRIPTION
## Why this should be merged
Adds an e2e test for `TeleporterUpgradeable` pause and unpause, fixes #242 

## How this works
- Deploy a dapp that uses `TeleporterRegistry` and `TeleporterOwnerUpgradeable`
- Pause the Teleporter address for the dapp
- Confirm Teleporter is paused for dapp
- Try to send a message to dapp through Teleporter that should fail
- Unpause Teleporter address
- Send another message to dapp, which should now succeed

## How this was tested
CI

## How is this documented
n/a