### PR TITLE
refactored basic_send_receive.sh

### DIFF
--- a/scripts/local/examples/basic_send_receive.sh
+++ b/scripts/local/examples/basic_send_receive.sh
@@ -2,140 +2,180 @@
 # Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 # See the file LICENSE for licensing terms.
 
-set -e # Stop on first error
+set -e # stop on first error
 
-# Variables provided by run_setup.sh:
-#   user_private_key
-#   user_address
-#   c_chain_blockchain_id
-#   subnet_a_blockchain_id
-#   c_chain_subnet_id
-#   subnet_a_subnet_id
-#   c_chain_rpc_url
-#   subnet_a_subnet_id
-#   c_chain_blockchain_id_hex
-#   subnet_a_blockchain_id_hex
-#   teleporter_contract_address
-#   warp_messenger_precompile_addr
+##
+## Variables provided by run_setup.sh
+##
 
-# Test covers:
-# - Sending bidirectional cross chain messages between the C-Chain and a subnet chain, by calling Teleporter contract sendCrossChainMessage function directly.
-# - Checking message delivery for message that was sent on destination chain.
-# - Calling to the warp precompile address directly for blockchain ID.
+my_pk=$user_private_key
+my_0x=$user_address
+c_bid=$c_chain_blockchain_id
+a_bid=$subnet_a_blockchain_id
+c_sid=$c_chain_subnet_id
+a_sid=$subnet_a_subnet_id
+c_rpc=$c_chain_rpc_url
+a_rpc=$subnet_a_rpc_url
+c_bix=$c_chain_blockchain_id_hex
+a_bix=$subnet_a_blockchain_id_hex
+tp_0x=$teleporter_contract_address
+wm_0x=$warp_messenger_precompile_addr
 
-# Deploy a test ERC20 to be used in the E2E test.
+##
+## Test covers:
+## - Sending bidirectional cross chain messages between C-chain and a subnet chain,
+##   by calling the teleporter contract sendCrossChainMessage function directly.
+## - Checking message delivery for message that was sent on destination chain.
+## - Calling to the warp precompile address directly for blockchain ID.
+##
+
 cd contracts
-erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $c_chain_rpc_url)
-erc20_contract_address_c_chain=$(parseContractAddress "$erc20_deploy_result")
-echo "Test ERC20 contract deployed to $erc20_contract_address_c_chain on the C-Chain"
-erc20_deploy_result=$(forge create --private-key $user_private_key src/Mocks/ExampleERC20.sol:ExampleERC20 --rpc-url $subnet_a_rpc_url)
-erc20_contract_address_a=$(parseContractAddress "$erc20_deploy_result")
-echo "Test ERC20 contract deployed to $erc20_contract_address_a on subnet A"
 
-###
-# Send from the C-Chain -> subnet A
-###
-echo "Sending from the C-Chain to subnet A"
-blockchainID=$(cast call $warp_messenger_precompile_addr "getBlockchainID()(bytes32)" --rpc-url $c_chain_rpc_url)
-echo "Got blockchain ID $blockchainID"
+##
+## Deploy an ERC20 to be used in the E2E test
+##
 
-echo "Sending call to teleporter contract address $teleporter_contract_address $subnet_a_blockchain_id_hex $c_chain_rpc_url"
-result=$(cast call $teleporter_contract_address "getNextMessageID(bytes32)(bytes32)" $subnet_a_blockchain_id_hex --rpc-url $c_chain_rpc_url)
-echo "Next message ID for subnet $subnet_a_blockchain_id_hex is $result"
+erc=$(forge create \
+    --rpc-url $c_rpc --private-key $my_pk src/Mocks/ExampleERC20.sol:ExampleERC20)
+erc_c0x=$(parseContractAddress "$erc")
+echo "ERC20 deployed to $erc_c0x on C-chain"
 
-# Directly send a transaction to the teleporter contract sendCrossChainMessage function.
-send_cross_subnet_message_destination_chain_id=$subnet_a_blockchain_id_hex
-send_cross_subnet_message_destination_address=abcedf1234abcedf1234abcedf1234abcedf1234
-send_bytes32=000000000000000000000000$send_cross_subnet_message_destination_address
-send_cross_subnet_message_fee_amount=255
-send_cross_subnet_message_required_gas_limit=10000
-send_cross_subnet_message_message_data=cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafe
+erc=$(forge create \
+    --rpc-url $a_rpc --private-key $my_pk src/Mocks/ExampleERC20.sol:ExampleERC20)
+erc_a0x=$(parseContractAddress "$erc")
+echo "ERC20 deployed to $erc_a0x on subnet A"
 
-# Approve the Teleporter contract to some ERC20 tokens from the user account we're using to send transactions
-approve_amount=100000000000000000000000000000
-cast send $erc20_contract_address_c_chain "approve(address,uint256)(bool)" $teleporter_contract_address \
-    $approve_amount \
-    --private-key $user_private_key --rpc-url $c_chain_rpc_url
-result=$(cast call $erc20_contract_address_c_chain "allowance(address,address)(uint256)" $user_address $teleporter_contract_address --rpc-url $c_chain_rpc_url)
-result=$(echo $result | cut -d' ' -f1)
-if [[ $result -ne $approve_amount ]]; then
-    echo $result
-    echo $approve_amount
-    echo "Error approving Teleporter contract to spend ERC20 from user account."
+##
+## Send from C-chain to subnet A
+##
+
+echo "Sending from C-chain to subnet A"
+bid=$(cast call $wm_0x "getBlockchainID()(bytes32)" --rpc-url $c_rpc)
+echo "Got blockchain ID $bid"
+
+echo "Sending call to teleporter $tp_0x $a_bix $c_rpc"
+mid=$(cast call $tp_0x "getNextMessageID(bytes32)(bytes32)" $a_bix --rpc-url $c_rpc)
+echo "Next message ID for subnet $a_bix is $mid"
+
+##
+## Directly send a TX to teleporter's sendCrossChainMessage
+##
+
+sccm_tgt_id=$a_bix
+sccm_tgt_0x=abcedf1234abcedf1234abcedf1234abcedf1234
+send_bytes32=000000000000000000000000$sccm_tgt_0x
+sccm_fee=255
+sccm_gas=10000
+sccm_data=cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafe
+
+##
+## Approve teleporter to some ERC20 from user for TXs
+##
+
+approve_u256=100000000000000000000000000000
+cast send $erc_c0x \
+    "approve(address,uint256)(bool)" $tp_0x $approve_u256 \
+    --rpc-url $c_rpc --private-key $my_pk
+u256=$(cast call $erc_c0x \
+    "allowance(address,address)(uint256)" $my_0x $tp_0x \
+    --rpc-url $c_rpc)
+u256=$(echo $u256 | cut -d' ' -f1)
+if [[ $u256 -ne $approve_u256 ]]; then
+    echo $u256
+    echo $approve_u256
+    echo "Approving teleporter to spend ERC20 from user failed"
     exit 1
+else
+    echo "Approved teleporter to spend the test ERC20 token from user"
 fi
 
-echo "Approved the Teleporter contract to spend the test ERC20 token from the user account."
+mid=$(cast call $tp_0x \
+    "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(bytes32)" \
+    "($sccm_tgt_id,$sccm_tgt_0x,($erc_c0x,$sccm_fee),$sccm_gas,[],$sccm_data)" \
+    --rpc-url $c_rpc --from $my_0x)
+echo "Got starting ID $mid to teleport address $tp_0x"
+cast send $tp_0x \
+    "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(bytes32)" \
+    "($sccm_tgt_id,$sccm_tgt_0x,($erc_c0x,$sccm_fee),$sccm_gas,[],$sccm_data)" \
+    --rpc-url $c_rpc --private-key $my_pk
 
-startID=$(cast call $teleporter_contract_address "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(bytes32)" "($send_cross_subnet_message_destination_chain_id,$send_cross_subnet_message_destination_address,($erc20_contract_address_c_chain,$send_cross_subnet_message_fee_amount),$send_cross_subnet_message_required_gas_limit,[],$send_cross_subnet_message_message_data)" --from $user_address --rpc-url $c_chain_rpc_url)
-echo "Got starting ID $startID to teleport address $teleporter_contract_address"
-cast send $teleporter_contract_address "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(bytes32)" "($send_cross_subnet_message_destination_chain_id,$send_cross_subnet_message_destination_address,($erc20_contract_address_c_chain,$send_cross_subnet_message_fee_amount),$send_cross_subnet_message_required_gas_limit,[],$send_cross_subnet_message_message_data)" --private-key $user_private_key --rpc-url $c_chain_rpc_url
-
-retry_count=0
-received=$(cast call $teleporter_contract_address "messageReceived(bytes32)(bool)" $startID --rpc-url $subnet_a_rpc_url)
-until [[ $received == "true" ]]
-do
-    if [[ retry_count -ge 10 ]]; then
-        echo "Destination chain on Subnet A did not receive message before timeout."
+idx=0
+msg=$(cast call $tp_0x "messageReceived(bytes32)(bool)" $mid --rpc-url $a_rpc)
+until [[ $msg == "true" ]]; do
+    if [[ idx -ge 10 ]]; then
+        echo "Destination chain on subnet A did not receive message before timeout"
         exit 1
     fi
-    echo "Waiting for destination chain on Subnet A to receive message ID $startID. Retry count: $retry_count"
+    echo "Waiting for destination chain on subnet A to receive message ID $mid; retry count: $idx"
     sleep 3
-
-    received=$(cast call $teleporter_contract_address "messageReceived(bytes32)(bool)" $startID --rpc-url $subnet_a_rpc_url)
-    retry_count=$((retry_count+1))
+    msg=$(cast call $tp_0x "messageReceived(bytes32)(bool)" $mid --rpc-url $a_rpc)
+    idx=$((idx + 1))
 done
 
-echo "Received on Subnet A is $received"
+echo "Received on subnet A is $msg"
 
+##
+## Send from subnet A to C-Chain
+##
 
-###
-# Send from subnet A -> the C-Chain
-###
-echo "Sending from subnet A to the C-Chain"
-blockchainID=$(cast call $warp_messenger_precompile_addr "getBlockchainID()(bytes32)" --rpc-url $subnet_a_rpc_url)
-echo "Got blockchain ID $blockchainID"
+echo "Sending from subnet A to C-Chain"
+bid=$(cast call $wm_0x "getBlockchainID()(bytes32)" --rpc-url $a_rpc)
+echo "Got blockchain ID $bid"
 
-echo "Sending call to teleporter contract address $teleporter_contract_address $c_chain_blockchain_id_hex $subnet_a_subnet_id"
-result=$(cast call $teleporter_contract_address "getNextMessageID(bytes32)(bytes32)" $c_chain_blockchain_id_hex --rpc-url $subnet_a_rpc_url)
-echo "Next message ID for subnet $c_chain_blockchain_id_hex is $result"
+echo "Sending call to teleporter $tp_0x $c_bix $a_sid"
+mid=$(cast call $tp_0x "getNextMessageID(bytes32)(bytes32)" $c_bix --rpc-url $a_rpc)
+echo "Next message ID for subnet $c_bix is $mid"
 
-# Directly send a few transaction to the teleporter contract sendCrossChainMessage function.
-send_cross_subnet_message_destination_chain_id=$c_chain_blockchain_id_hex
-send_cross_subnet_message_destination_address=abcedf1234abcedf1234abcedf1234abcedf1234
-send_bytes32=000000000000000000000000$send_cross_subnet_message_destination_address
-send_cross_subnet_message_message_data=cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafe
+##
+## Directly send a few TXs to teleporter's sendCrossChainMessage
+##
 
-# Approve the teleporter contract to some ERC20 tokens from the user account we're using to send transactions
-cast send $erc20_contract_address_a "approve(address,uint256)(bool)" $teleporter_contract_address $approve_amount --private-key $user_private_key --rpc-url $subnet_a_rpc_url
-result=$(cast call $erc20_contract_address_a "allowance(address,address)(uint256)" $user_address $teleporter_contract_address --rpc-url $subnet_a_rpc_url)
-result=$(echo $result | cut -d' ' -f1)
-if [[ $result -ne $approve_amount ]]; then
-    echo $result
-    echo "Error approving Teleporter contract to spend ERC20 from user account."
+sccm_tgt_id=$c_bix
+sccm_tgt_0x=abcedf1234abcedf1234abcedf1234abcedf1234
+send_bytes32=000000000000000000000000$sccm_tgt_0x
+sccm_data=cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafe
+
+##
+## Approve teleporter to some ERC20 from user for TXs
+##
+
+cast send $erc_a0x \
+    "approve(address,uint256)(bool)" $tp_0x $approve_u256 \
+    --rpc-url $a_rpc --private-key $my_pk
+mid=$(cast call $erc_a0x \
+    "allowance(address,address)(uint256)" $my_0x $tp_0x \
+    --rpc-url $a_rpc)
+mid=$(echo $mid | cut -d' ' -f1)
+if [[ $mid -ne $approve_u256 ]]; then
+    echo $mid
+    echo "Approving teleporter to spend ERC20 from user failed"
     exit 1
+else
+    echo "Approved teleporter to spend the test ERC20 from user"
 fi
 
-echo "Approved the Teleporter contract to spend the test ERC20 token from the user account."
+mid=$(cast call $tp_0x \
+    "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(bytes32)" \
+    "($sccm_tgt_id,$sccm_tgt_0x,($erc_a0x,$sccm_fee),$sccm_gas,[],$sccm_data)" \
+    --rpc-url $a_rpc --from $my_0x)
+echo "Got starting ID $mid to teleport address $tp_0x"
+echo "Got IDs $a_bix $c_bix $a_sid $c_sid"
+cast send $tp_0x \
+    "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(bytes32)" \
+    "($sccm_tgt_id,$sccm_tgt_0x,($erc_a0x,$sccm_fee),$sccm_gas,[],$sccm_data)" \
+    --rpc-url $a_rpc --private-key $my_pk
 
-startID=$(cast call $teleporter_contract_address "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(bytes32)" "($send_cross_subnet_message_destination_chain_id,$send_cross_subnet_message_destination_address,($erc20_contract_address_a,$send_cross_subnet_message_fee_amount),$send_cross_subnet_message_required_gas_limit,[],$send_cross_subnet_message_message_data)" --from $user_address --rpc-url $subnet_a_rpc_url)
-echo "Got starting ID $startID to teleport address $teleporter_contract_address"
-echo "Got Ids $subnet_a_blockchain_id_hex $c_chain_blockchain_id_hex $subnet_a_subnet_id $c_chain_subnet_id"
-cast send $teleporter_contract_address "sendCrossChainMessage((bytes32,address,(address,uint256),uint256,address[],bytes))(bytes32)" "($send_cross_subnet_message_destination_chain_id,$send_cross_subnet_message_destination_address,($erc20_contract_address_a,$send_cross_subnet_message_fee_amount),$send_cross_subnet_message_required_gas_limit,[],$send_cross_subnet_message_message_data)" --private-key $user_private_key --rpc-url $subnet_a_rpc_url
-
-retry_count=0
-received=$(cast call $teleporter_contract_address "messageReceived(bytes32)(bool)" $startID --rpc-url $c_chain_rpc_url)
-until [[ $received == "true" ]]
-do
-    if [[ retry_count -ge 10 ]]; then
-        echo "C-Chain did not receive message before timeout."
+idx=0
+msg=$(cast call $tp_0x "messageReceived(bytes32)(bool)" $mid --rpc-url $c_rpc)
+until [[ $msg == "true" ]]; do
+    if [[ idx -ge 10 ]]; then
+        echo "C-Chain did not receive message before timeout"
         exit 1
     fi
-    echo "Waiting for the C-Chain to receive message ID $startID. Retry count: $retry_count"
+    echo "Waiting for C-chain to receive message ID $mid; retry count: $idx"
     sleep 3
-
-    received=$(cast call $teleporter_contract_address "messageReceived(bytes32)(bool)" $startID  --rpc-url $c_chain_rpc_url)
-    retry_count=$((retry_count+1))
+    msg=$(cast call $tp_0x "messageReceived(bytes32)(bool)" $mid --rpc-url $c_rpc)
+    idx=$((idx + 1))
 done
 
-echo "Received on the C-Chain is $received"
+echo "Received on C-chain is $msg"


### PR DESCRIPTION
The original code was not readable due to long variable names. Hence, renamed and slightly reformatted the code to increase readability.