### PR TITLE
Remove Durango config

### DIFF
--- a/docker/docker-compose-run.yml
+++ b/docker/docker-compose-run.yml
@@ -21,7 +21,7 @@ services:
         source: ./
         target: /code/
   relayer:
-    image: avaplatform/awm-relayer:v0.2.8
+    image: avaplatform/awm-relayer:v0.2.9
     container_name: relayer_run
     init: true
     working_dir: /code

--- a/docker/genesisTemplate.json
+++ b/docker/genesisTemplate.json
@@ -11,8 +11,6 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
-    "dUpgradeTimestamp": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/docker/relayerConfigTemplate.json
+++ b/docker/relayerConfigTemplate.json
@@ -2,6 +2,7 @@
     "network-id": 1337,
     "p-chain-api-url": "http://127.0.0.1:9650",
     "encrypt-connection": false,
+    "process-missed-blocks": false,
     "source-subnets": [
         {
             "subnet-id": "11111111111111111111111111111111LpoYY",

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -29,7 +29,7 @@ extract_commit() {
 }
 
 # AWM_RELAYER_VERSION is needed for the docker run setup, but is not a go module dependency.
-AWM_RELAYER_VERSION=${AWM_RELAYER_VERSION:-'v0.2.8'}
+AWM_RELAYER_VERSION=${AWM_RELAYER_VERSION:-'v0.2.9'}
 
 # This needs to be exported to be picked up by the dockerfile.
 export GO_VERSION=${GO_VERSION:-$(getDepVersion go).$GO_PATCH_VERSION}


### PR DESCRIPTION
## Why this should be merged
Fixes https://github.com/ava-labs/teleporter/issues/263.

Note: this is caused by a bug in avalanche-network-runner that has been [merged](https://github.com/ava-labs/avalanche-network-runner/pull/697), but not yet included in a release. We may need to revert this change once it is patched there.

~~We will wait to merge until https://github.com/ava-labs/awm-relayer/pull/161 is merged, and a new awm-relayer release published.~~ This PR is ready to merge.

## How this works
- Fixes the genesis config to be compatible with ANR
- Bumps awm-relayer version to latest

## How this was tested
CI, manually verified that the example script runs using the latest awm-relayer image

## How is this documented