### PR TITLE
fix: build with local awm image flag

### DIFF
--- a/scripts/local/run.sh
+++ b/scripts/local/run.sh
@@ -47,7 +47,7 @@ trap cleanup SIGINT
 # It is referenced in the docker composer yaml, and then passed as a Dockerfile ARG
 setARCH
 
-if [ -z "$LOCAL_RELAYER_IMAGE" ]; then
+if [ -l "$LOCAL_RELAYER_IMAGE" ]; then
     echo "Using published awm-relayer image"
     docker compose -f docker/docker-compose-run.yml --project-directory ./ up --abort-on-container-exit --build &
 else


### PR DESCRIPTION
## Why this should be merged

typo meant
`run.sh` script would always build with the dockerhub AWM image

## How this works

~-z~ -> -l

## How this was tested

`./scripts/local/run.sh -l` _before_ change produces `Using published awm-relayer image` in docker log

`./scripts/local/run.sh -l` _after_ change produces `Using local awm-relayer image:` in docker log
