### PR TITLE
Remove most uses of Websocket Client

### DIFF
--- a/tests/flows/erc20_to_native_token_bridge.go
+++ b/tests/flows/erc20_to_native_token_bridge.go
@@ -132,17 +132,17 @@ func ERC20ToNativeTokenBridge(network interfaces.LocalNetwork) {
 	// Create abi objects to call the contract with
 	nativeTokenDestination, err := nativetokendestination.NewNativeTokenDestination(
 		bridgeContractAddress,
-		destSubnet.WSClient,
+		destSubnet.RPCClient,
 	)
 	Expect(err).Should(BeNil())
 	erc20TokenSource, err := erc20tokensource.NewERC20TokenSource(
 		bridgeContractAddress,
-		sourceSubnet.WSClient,
+		sourceSubnet.RPCClient,
 	)
 	Expect(err).Should(BeNil())
 	exampleERC20, err := exampleerc20.NewExampleERC20(
 		exampleERC20ContractAddress,
-		sourceSubnet.WSClient,
+		sourceSubnet.RPCClient,
 	)
 	Expect(err).Should(BeNil())
 
@@ -162,7 +162,7 @@ func ERC20ToNativeTokenBridge(network interfaces.LocalNetwork) {
 	{
 		// Transfer some tokens A -> B
 		// Check starting balance is 0
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.RPCClient)
 
 		checkReserveImbalance(initialReserveImbalance, nativeTokenDestination)
 
@@ -194,13 +194,13 @@ func ERC20ToNativeTokenBridge(network interfaces.LocalNetwork) {
 		checkReserveImbalance(intermediateReserveImbalance, nativeTokenDestination)
 
 		// Check intermediate balance, no tokens should be minted because we haven't collateralized
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.RPCClient)
 	}
 
 	{
 		// Fail to Transfer tokens B -> A because bridge is not collateralized
 		// Check starting balance is 0
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.RPCClient)
 
 		transactor, err := bind.NewKeyedTransactorWithChainID(deployerPK, destSubnet.EVMChainID)
 		Expect(err).Should(BeNil())
@@ -217,13 +217,13 @@ func ERC20ToNativeTokenBridge(network interfaces.LocalNetwork) {
 		checkReserveImbalance(intermediateReserveImbalance, nativeTokenDestination)
 
 		// Check we failed to send because we're not collateralized
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.RPCClient)
 	}
 
 	{
 		// Transfer more tokens A -> B to collateralize the bridge
 		// Check starting balance is 0
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.RPCClient)
 
 		checkReserveImbalance(intermediateReserveImbalance, nativeTokenDestination)
 
@@ -256,7 +256,7 @@ func ERC20ToNativeTokenBridge(network interfaces.LocalNetwork) {
 		checkReserveImbalance(common.Big0, nativeTokenDestination)
 
 		// We should have minted the excess coins after checking the collateral
-		utils.CheckBalance(ctx, tokenReceiverAddress, valueToSend, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, valueToSend, destSubnet.RPCClient)
 	}
 
 	{

--- a/tests/flows/native_token_bridge.go
+++ b/tests/flows/native_token_bridge.go
@@ -122,19 +122,19 @@ func NativeTokenBridge(network interfaces.LocalNetwork) {
 	// Create abi objects to call the contract with
 	nativeTokenDestination, err := nativetokendestination.NewNativeTokenDestination(
 		bridgeContractAddress,
-		destSubnet.WSClient,
+		destSubnet.RPCClient,
 	)
 	Expect(err).Should(BeNil())
 	nativeTokenSource, err := nativetokensource.NewNativeTokenSource(
 		bridgeContractAddress,
-		sourceSubnet.WSClient,
+		sourceSubnet.RPCClient,
 	)
 	Expect(err).Should(BeNil())
 
 	{
 		// Transfer some tokens A -> B
 		// Check starting balance is 0
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.RPCClient)
 
 		checkReserveImbalance(initialReserveImbalance, nativeTokenDestination)
 
@@ -168,13 +168,13 @@ func NativeTokenBridge(network interfaces.LocalNetwork) {
 		Expect(err).ShouldNot(BeNil())
 
 		// Check intermediate balance, no tokens should be minted because we haven't collateralized
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.RPCClient)
 	}
 
 	{
 		// Fail to Transfer tokens B -> A because bridge is not collateralized
 		// Check starting balance is 0
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, sourceSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, sourceSubnet.RPCClient)
 
 		transactor, err := bind.NewKeyedTransactorWithChainID(deployerPK, destSubnet.EVMChainID)
 		Expect(err).Should(BeNil())
@@ -190,13 +190,13 @@ func NativeTokenBridge(network interfaces.LocalNetwork) {
 		Expect(err).ShouldNot(BeNil())
 
 		// Check we should fail to send because we're not collateralized
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, sourceSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, sourceSubnet.RPCClient)
 	}
 
 	{
 		// Transfer more tokens A -> B to collateralize the bridge
 		// Check starting balance is 0
-		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, common.Big0, destSubnet.RPCClient)
 		checkReserveImbalance(
 			big.NewInt(0).Sub(initialReserveImbalance, valueToSend),
 			nativeTokenDestination,
@@ -229,7 +229,7 @@ func NativeTokenBridge(network interfaces.LocalNetwork) {
 		checkReserveImbalance(common.Big0, nativeTokenDestination)
 
 		// We should have minted the excess coins after checking the collateral
-		utils.CheckBalance(ctx, tokenReceiverAddress, valueToSend, destSubnet.WSClient)
+		utils.CheckBalance(ctx, tokenReceiverAddress, valueToSend, destSubnet.RPCClient)
 	}
 
 	{


### PR DESCRIPTION
## Why this should be merged
Removes all uses of the Websocket Client except for in `validator_churn.go`. We had originally used it to wait for transactions to be mined, but looping on the RPC client waiting for a transaction hash to be mined easier, more robust on testnets, and only requires one type of endpoint.

## How this works
`IssueTxsToActivateProposerVMFork` in `subnet-evm` requires a websocket client, so we cannot totally eliminate our use of it.

## How this was tested
Existing E2E tests

## How is this documented