### PR TITLE
Extra checks and tests for native token bridge

### DIFF
--- a/contracts/src/CrossChainApplications/examples/NativeTokenBridge/ERC20TokenSource.sol
+++ b/contracts/src/CrossChainApplications/examples/NativeTokenBridge/ERC20TokenSource.sol
@@ -62,6 +62,7 @@ contract ERC20TokenSource is IERC20TokenSource, TokenSource {
 
         // The recipient cannot be the zero address.
         require(recipient != address(0), "ERC20TokenSource: zero recipient address");
+        require(totalAmount > 0, "ERC20TokenSource: zero transfer amount");
 
         // Lock tokens in this contract. Supports "fee/burn on transfer" ERC20 token
         // implementations by only bridging the actual balance increase reflected by the call

--- a/contracts/src/CrossChainApplications/examples/NativeTokenBridge/NativeTokenSource.sol
+++ b/contracts/src/CrossChainApplications/examples/NativeTokenBridge/NativeTokenSource.sol
@@ -54,6 +54,8 @@ contract NativeTokenSource is INativeTokenSource, TokenSource {
 
         // The recipient cannot be the zero address.
         require(recipient != address(0), "NativeTokenSource: zero recipient address");
+        uint256 value = msg.value;
+        require(value > 0, "NativeTokenSource: zero transfer value");
 
         // Lock tokens in this bridge instance. Supports "fee/burn on transfer" ERC20 token
         // implementations by only bridging the actual balance increase reflected by the call
@@ -75,14 +77,14 @@ contract NativeTokenSource is INativeTokenSource, TokenSource {
                 feeInfo: feeInfo,
                 requiredGasLimit: MINT_NATIVE_TOKENS_REQUIRED_GAS,
                 allowedRelayerAddresses: allowedRelayerAddresses,
-                message: abi.encode(recipient, msg.value)
+                message: abi.encode(recipient, value)
             })
         );
 
         emit TransferToDestination({
             sender: msg.sender,
             recipient: recipient,
-            amount: msg.value,
+            amount: value,
             teleporterMessageID: messageID
         });
     }

--- a/contracts/src/CrossChainApplications/examples/NativeTokenBridge/tests/ERC20TokenSourceTests.t.sol
+++ b/contracts/src/CrossChainApplications/examples/NativeTokenBridge/tests/ERC20TokenSourceTests.t.sol
@@ -270,6 +270,20 @@ contract ERC20TokenSourceTest is NativeTokenBridgeTest {
         );
     }
 
+    function testTransferZeroAmount() public {
+        vm.expectRevert(_formatERC20TokenSourceErrorMessage("zero transfer amount"));
+
+        erc20TokenSource.transferToDestination(_DEFAULT_RECIPIENT, 0, 0, new address[](0));
+    }
+
+    function testInsufficientAdjustedAmount() public {
+        vm.expectRevert(_formatERC20TokenSourceErrorMessage("insufficient adjusted amount"));
+
+        erc20TokenSource.transferToDestination(
+            _DEFAULT_RECIPIENT, _DEFAULT_TRANSFER_AMOUNT, _DEFAULT_TRANSFER_AMOUNT, new address[](0)
+        );
+    }
+
     function _formatERC20TokenSourceErrorMessage(string memory errorMessage)
         private
         pure

--- a/contracts/src/CrossChainApplications/examples/NativeTokenBridge/tests/NativeTokenDestinationTests.t.sol
+++ b/contracts/src/CrossChainApplications/examples/NativeTokenBridge/tests/NativeTokenDestinationTests.t.sol
@@ -15,6 +15,7 @@ import {
 } from "../NativeTokenDestination.sol";
 import {INativeMinter} from
     "@avalabs/subnet-evm-contracts@1.2.0/contracts/interfaces/INativeMinter.sol";
+import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";
 
 contract NativeTokenDestinationTest is NativeTokenBridgeTest {
     NativeTokenDestination public nativeTokenDestination;
@@ -178,6 +179,21 @@ contract NativeTokenDestinationTest is NativeTokenBridgeTest {
             abi.encodeCall(ITeleporterMessenger.sendCrossChainMessage, (expectedMessageInput))
         );
 
+        vm.expectCall(
+            address(mockERC20),
+            abi.encodeCall(
+                IERC20.transferFrom,
+                (address(this), address(nativeTokenDestination), _DEFAULT_FEE_AMOUNT)
+            )
+        );
+        vm.expectCall(
+            address(mockERC20),
+            abi.encodeCall(
+                IERC20.allowance,
+                (address(nativeTokenDestination), MOCK_TELEPORTER_MESSENGER_ADDRESS)
+            )
+        );
+
         nativeTokenDestination.reportTotalBurnedTxFees(
             TeleporterFeeInfo({feeTokenAddress: address(mockERC20), amount: _DEFAULT_FEE_AMOUNT}),
             new address[](0)
@@ -316,6 +332,17 @@ contract NativeTokenDestinationTest is NativeTokenBridgeTest {
         vm.expectRevert(_formatNativeTokenDestinationErrorMessage("contract undercollateralized"));
 
         nativeTokenDestination.transferToSource{value: _DEFAULT_TRANSFER_AMOUNT}(
+            _DEFAULT_RECIPIENT,
+            TeleporterFeeInfo({feeTokenAddress: address(mockERC20), amount: _DEFAULT_FEE_AMOUNT}),
+            new address[](0)
+        );
+    }
+
+    function testTransferZeroAmount() public {
+        collateralizeBridge();
+        vm.expectRevert(_formatNativeTokenDestinationErrorMessage("zero transfer value"));
+
+        nativeTokenDestination.transferToSource{value: 0}(
             _DEFAULT_RECIPIENT,
             TeleporterFeeInfo({feeTokenAddress: address(mockERC20), amount: _DEFAULT_FEE_AMOUNT}),
             new address[](0)

--- a/contracts/src/CrossChainApplications/examples/NativeTokenBridge/tests/NativeTokenSourceTests.t.sol
+++ b/contracts/src/CrossChainApplications/examples/NativeTokenBridge/tests/NativeTokenSourceTests.t.sol
@@ -275,6 +275,16 @@ contract NativeTokenSourceTest is NativeTokenBridgeTest {
         );
     }
 
+    function testTransferZeroAmount() public {
+        vm.expectRevert(_formatNativeTokenSourceErrorMessage("zero transfer value"));
+
+        nativeTokenSource.transferToDestination{value: 0}(
+            _DEFAULT_RECIPIENT,
+            TeleporterFeeInfo({feeTokenAddress: address(mockERC20), amount: _DEFAULT_FEE_AMOUNT}),
+            new address[](0)
+        );
+    }
+
     function _formatNativeTokenSourceErrorMessage(string memory errorMessage)
         private
         pure


### PR DESCRIPTION
## Why this should be merged
Adding zero transfer amount checks to native token bridge, and handling fee transfer for `reportTotalBurnedFees`, including unit tests.

## How this works
For 3 native token bridge related contracts add check for zero transfer amounts. Also need to handle fee for `reportTotalBurnedFees` to transferring to the contract then allowing Teleporter.

## How this was tested
Unit tests
CI

## How is this documented
n/a