### PR TITLE
Check deployment prior to broadcasting Nick's method tx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           export PATH=$PATH:$HOME/.foundry/bin
           cd contracts/
-          forge build
+          forge build --force --extra-output-files bin
 
       - name: Build changelog
         id: build_changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,5 +71,4 @@ jobs:
             ${{ env.deployer_addr_fn }}
             ${{ env.contract_addr_fn }}
             ${{ env.teleporter_messenger_bytecode_fn }}
-            ${{ env.teleporter_registry_bytecode_fn }}
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
       deployment_tx_fn: TeleporterMessenger_Deployment_Transaction_${{ github.ref_name }}.txt
       deployer_addr_fn: TeleporterMessenger_Deployer_Address_${{ github.ref_name }}.txt
       contract_addr_fn: TeleporterMessenger_Contract_Address_${{ github.ref_name }}.txt
+      teleporter_messenger_bytecode_fn: TeleporterMessenger_Bytecode_${{ github.ref_name }}.txt
+      teleporter_registry_bytecode_fn: TeleporterRegistry_Bytecode_${{ github.ref_name }}.txt
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -56,6 +58,8 @@ jobs:
           mv UniversalTeleporterDeployerTransaction.txt ${{ env.deployment_tx_fn }}
           mv UniversalTeleporterDeployerAddress.txt ${{ env.deployer_addr_fn }}
           mv UniversalTeleporterMessengerContractAddress.txt ${{ env.contract_addr_fn }}
+          mv contracts/out/TeleporterMessenger.sol/TeleporterMessenger.bin ${{ env.teleporter_messenger_bytecode_fn }}
+          mv contracts/out/TeleporterRegistry.sol/TeleporterRegistry.bin ${{ env.teleporter_registry_bytecode_fn }}
 
       - name: Create release
         uses: softprops/action-gh-release@v1
@@ -68,4 +72,6 @@ jobs:
             ${{ env.deployment_tx_fn }}
             ${{ env.deployer_addr_fn }}
             ${{ env.contract_addr_fn }}
+            ${{ env.teleporter_messenger_bytecode_fn }}
+            ${{ env.teleporter_registry_bytecode_fn }}
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
       deployer_addr_fn: TeleporterMessenger_Deployer_Address_${{ github.ref_name }}.txt
       contract_addr_fn: TeleporterMessenger_Contract_Address_${{ github.ref_name }}.txt
       teleporter_messenger_bytecode_fn: TeleporterMessenger_Bytecode_${{ github.ref_name }}.txt
-      teleporter_registry_bytecode_fn: TeleporterRegistry_Bytecode_${{ github.ref_name }}.txt
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -59,7 +58,6 @@ jobs:
           mv UniversalTeleporterDeployerAddress.txt ${{ env.deployer_addr_fn }}
           mv UniversalTeleporterMessengerContractAddress.txt ${{ env.contract_addr_fn }}
           mv contracts/out/TeleporterMessenger.sol/TeleporterMessenger.bin ${{ env.teleporter_messenger_bytecode_fn }}
-          mv contracts/out/TeleporterRegistry.sol/TeleporterRegistry.bin ${{ env.teleporter_registry_bytecode_fn }}
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/scripts/deploy_teleporter.sh
+++ b/scripts/deploy_teleporter.sh
@@ -61,13 +61,6 @@ while [ $# -gt 0 ]; do
                 echo "Invalid private key $2" && printHelp && exit 1
             fi 
             shift;;
-        --deploy-registry) 
-            if [[ $2 != --* ]]; then
-                registry_version_id=$2
-            else 
-                echo "Invalid version ID for TeleporterRegistry $2" && printHelp && exit 1
-            fi 
-            shift;;
         --help) 
             printHelp && exit 0 ;;
         *) 

--- a/scripts/deploy_teleporter.sh
+++ b/scripts/deploy_teleporter.sh
@@ -9,7 +9,7 @@ TELEPORTER_PATH=$(
     cd .. && pwd
 )
 
-# Check that foundry (specifically cast) is installed
+# Check that foundry (specifically cast) is installed.
 if ! command -v cast &> /dev/null; then
     echo "cast not found. You can install by calling $TELEPORTER_PATH/scripts/install_foundry.sh" && exit 1
 fi

--- a/scripts/deploy_teleporter.sh
+++ b/scripts/deploy_teleporter.sh
@@ -31,9 +31,6 @@ function printUsage() {
     echo "  --version <version>              Required. Specify the release version to deploy"
     echo "  --rpc-url <url>                  Required. Specify the rpc url of the node to use"
     echo "  --private-key <private_key>      Optional. Private key of account to use to fund the Teleporter deployer address, if necessary."
-    echo "  --deploy-registry <version_id>   Optional. If set, deploys a new TeleporterRegistry contract with the address"
-    echo "                                   of the TeleporterMessenger version deployed set for the given version ID."
-    echo "                                   Deploying a TeleporterRegistry instance requires a private key to be provided."
     echo "  --help                           Print this help message"
 }
 

--- a/scripts/deploy_teleporter.sh
+++ b/scripts/deploy_teleporter.sh
@@ -73,6 +73,11 @@ while [ $# -gt 0 ]; do
     shift
 done
 
+if [[ $teleporter_version == "" || $rpc_url == "" ]]; then
+    echo "Invalid usage. Teleporter version and RPC URL required."
+    printHelp && exit 1
+fi
+
 # Tokens required to deploy the contract.
 # Equal to contractCreationGasLimit * contractCreationGasPrice
 # from utils/deployment-utils/deployment_utils.go

--- a/scripts/deploy_teleporter.sh
+++ b/scripts/deploy_teleporter.sh
@@ -123,7 +123,7 @@ deployment_tx_id=$(echo $deployment_result | jq -r .transactionHash)
 if [[ $deployment_status != "0x1" ]]; then 
     echo "TeleporterMessenger deployment transaction failed. Transaction ID: $deployment_tx_id"
     echo "Check failure reason and, if necessary, investigate deployment through state upgrade."
-    echo "See https://github.com/ava-labs/subnet-evm/tree/master/stateupgrade."
+    echo "See https://github.com/ava-labs/subnet-evm/tree/master/stateupgrade"
     exit 1
 fi
 

--- a/scripts/deploy_teleporter.sh
+++ b/scripts/deploy_teleporter.sh
@@ -93,9 +93,9 @@ if [[ $teleporter_contract_code != "0" ]]; then
     echo "TeleporterMessenger $teleporter_version has already been deployed on this chain." && exit 0
 fi
 
-# Check if the deployer address is allowed to deploy contracts on this chain by attempting to
-# estimate the amount of gas required to deploy the TeleporterMessenger byte code from the Teleporter
-# deployer address.
+# Estimate the amount of gas required to deploy the TeleporterMessenger bytecode from the Teleporter
+# deployer address in order to simulate the transaction. This will error if the TeleporterMessenger
+# contract is unable to be deployed from the deployer address.
 cast estimate --rpc-url $rpc_url \
     --from $teleporter_deployer_address \
     --create $teleporter_messenger_bytecode > /dev/null

--- a/scripts/deploy_teleporter.sh
+++ b/scripts/deploy_teleporter.sh
@@ -9,11 +9,6 @@ TELEPORTER_PATH=$(
     cd .. && pwd
 )
 
-source $TELEPORTER_PATH/scripts/utils.sh
-
-setARCH
-setGrep
-
 if ! command -v forge &> /dev/null; then
     echo "forge not found. You can install by calling $TELEPORTER_PATH/scripts/install_foundry.sh" && exit 1
 fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -10,6 +10,11 @@ function parseContractAddress() {
     echo $1 | $grepcmd -o -P 'Deployed to: .{42}' | sed 's/^.\{13\}//';
 }
 
+# Parses the transaction status from "cast receipt" output.
+function parseTxStatus() {
+    echo $1 | $grepcmd 'status\s+\K\d+'
+}
+
 # use ggrep on arm64 otherwise grep -P returns error.
 # set ARCH before calling this function
 function setGrep() {

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -10,11 +10,6 @@ function parseContractAddress() {
     echo $1 | $grepcmd -o -P 'Deployed to: .{42}' | sed 's/^.\{13\}//';
 }
 
-# Parses the transaction status from "cast receipt" output.
-function parseTxStatus() {
-    echo $1 | $grepcmd 'status\s+\K\d+'
-}
-
 # use ggrep on arm64 otherwise grep -P returns error.
 # set ARCH before calling this function
 function setGrep() {


### PR DESCRIPTION
## Why this should be merged
Helps to avoid the issue described in #306. 

## How this works
Check that's the Teleporter deployer address is able to deploy the contract by simulating the transaction using `cast estimate`. 

## How this was tested
```
$ ./scripts/deploy_teleporter.sh --version v0.1.0 --rpc-url https://testnet-rpc.ferdyflip.xyz/rpc
TeleporterMessenger v0.1.0 contract address: 0x1b0505EaC728Efc30414ce0035BcC4DC5994a563
TeleporterMessenger v0.1.0 deployer address: 0xa21D65b03A07548F001b6C1422614BEa28370FdA
Error: 
(code: -32000, message: tx.origin 0xa21D65b03A07548F001b6C1422614BEa28370FdA is not authorized to deploy a contract, data: None)
```

## How this was documented
Error messages shown by script, and comments within it.
