### PR TITLE
Publish deployed addresses to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It's important to understand the distinction between Avalanche Warp Messaging an
 The Teleporter protocol, on the other hand, is implemented at the smart contract level, and is a user-friendly interface to AWM, aimed at dApp developers. All of the message signing and verification is abstracted away from developers. Instead, developers simply call `sendCrossChainMessage` on the `TeleporterMessenger` contract to send a message invoking a smart contract on another subnet, and implement the `ITeleporterReceiver` interface to receive messages on the destination subnet. Teleporter handles all of the Warp message construction and sending, as well as the message delivery and execution.
 
 - [Overview](#overview)
+- [Deployed Addresses](#deployed-addresses)
 - [Setup](#setup)
   - [Initialize the repository](#initialize-the-repository)
   - [Dependencies](#dependencies)
@@ -23,6 +24,18 @@ The Teleporter protocol, on the other hand, is implemented at the smart contract
 - [ABI Bindings](#abi-bindings)
 - [Docs](#docs)
 - [Resources](#resources)
+
+## Deployed Addresses
+
+| Contract              | Address                                        | Chain                    |
+| --------------------- | ---------------------------------------------- | ------------------------ |
+| `TeleporterMessenger` | **0x253b2784c75e510dD0fF1da844684a1aC0aa5fcf** | All chains, all networks |
+| `TeleporterRegistry`  | **0x7C43605E14F391720e1b37E49C78C4b03A488d98** | Mainnet C-Chain          |
+| `TeleporterRegistry`  | **0xf86cb19ad8405aefa7d09c778215d2cb6ebfb228** | Fuji C-Chain             |
+
+- `TeleporterMessenger` is deployed to the same address on all chains using Nick's method. See [Teleporter Contract Deployment](./utils/contract-deployment/README.md) and [Deploy Teleporter to a Subnet](#deploy-teleporter-to-a-subnet) for more details.
+
+- `TeleporterRegistry` can be deployed to any address. See [Deploy TeleporterRegistry to a Subnet](#deploy-teleporterregistry-to-a-subnet) The table above enumerates the canonical registry addresses on the Mainnet and Fuji C-Chains.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The Teleporter protocol, on the other hand, is implemented at the smart contract
 | `TeleporterRegistry`  | **0x7C43605E14F391720e1b37E49C78C4b03A488d98** | Mainnet C-Chain          |
 | `TeleporterRegistry`  | **0xf86cb19ad8405aefa7d09c778215d2cb6ebfb228** | Fuji C-Chain             |
 
-- `TeleporterMessenger` is deployed to the same address on all chains using Nick's method. See [Teleporter Contract Deployment](./utils/contract-deployment/README.md) and [Deploy Teleporter to a Subnet](#deploy-teleporter-to-a-subnet) for more details.
+- When deployed using [Nick's method](https://yamenmerhi.medium.com/nicks-method-ethereum-keyless-execution-168a6659479c#), `TeleporterMessenger` will be at the same address on all chains. See [Teleporter Contract Deployment](./utils/contract-deployment/README.md) and [Deploy Teleporter to a Subnet](#deploy-teleporter-to-a-subnet) for more details.
 
-- `TeleporterRegistry` can be deployed to any address. See [Deploy TeleporterRegistry to a Subnet](#deploy-teleporterregistry-to-a-subnet) The table above enumerates the canonical registry addresses on the Mainnet and Fuji C-Chains.
+- `TeleporterRegistry` can be deployed to any address. See [Deploy TeleporterRegistry to a Subnet](#deploy-teleporterregistry-to-a-subnet) for details. The table above enumerates the canonical registry addresses on the Mainnet and Fuji C-Chains.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The Teleporter protocol, on the other hand, is implemented at the smart contract
 | --------------------- | ---------------------------------------------- | ------------------------ |
 | `TeleporterMessenger` | **0x253b2784c75e510dD0fF1da844684a1aC0aa5fcf** | All chains, all networks |
 | `TeleporterRegistry`  | **0x7C43605E14F391720e1b37E49C78C4b03A488d98** | Mainnet C-Chain          |
-| `TeleporterRegistry`  | **0xf86cb19ad8405aefa7d09c778215d2cb6ebfb228** | Fuji C-Chain             |
+| `TeleporterRegistry`  | **0xF86Cb19Ad8405AEFa7d09C778215D2Cb6eBfB228** | Fuji C-Chain             |
 
 - When deployed using [Nick's method](https://yamenmerhi.medium.com/nicks-method-ethereum-keyless-execution-168a6659479c#), `TeleporterMessenger` will be at the same address on all chains. See [Teleporter Contract Deployment](./utils/contract-deployment/README.md) and [Deploy Teleporter to a Subnet](#deploy-teleporter-to-a-subnet) for more details.
 


### PR DESCRIPTION
## Why this should be merged
Adds the deployed Teleporter v1.0.0 addresses to the README. Included addresses are:
- TeleporterMessenger (same on all chains)
- TeleporterRegistry on the Fuji and Mainnet C-Chains

## How this works

## How this was tested

## How is this documented