### PR TITLE
Testnet E2E test cleanup

### DIFF
--- a/contracts/src/.solhint.json
+++ b/contracts/src/.solhint.json
@@ -1,7 +1,10 @@
 {
     "extends": "solhint:recommended",
     "rules": {
-        "compiler-version": ["error", "0.8.18"],
+        "compiler-version": [
+            "error",
+            "0.8.18"
+        ],
         "no-unused-vars": "error",
         "func-visibility": [
             "error",
@@ -21,7 +24,7 @@
                 "maxLength": 75
             }
         ],
-        "custom-errors": "off",
+        "gas-custom-errors": "off",
         "ordering": "error",
         "immutable-vars-naming": [
             "warn",
@@ -29,7 +32,10 @@
                 "immutablesAsConstants": false
             }
         ],
-        "func-named-parameters": ["error", 5],
+        "func-named-parameters": [
+            "error",
+            5
+        ],
         "one-contract-per-file": "off"
     }
 }

--- a/tests/flows/check_upgrade_access.go
+++ b/tests/flows/check_upgrade_access.go
@@ -68,14 +68,11 @@ func CheckUpgradeAccess(network interfaces.Network) {
 	tx, err := exampleMessenger.PauseTeleporterAddress(ownerOpts, teleporterAddress)
 	Expect(err).Should(BeNil())
 	receipt := utils.WaitForTransactionSuccess(ctx, subnetInfo, tx.Hash())
-	blockNum := receipt.BlockNumber
 	pauseTeleporterEvent, err := utils.GetEventFromLogs(receipt.Logs, exampleMessenger.ParseTeleporterAddressPaused)
 	Expect(err).Should(BeNil())
 	Expect(pauseTeleporterEvent.TeleporterAddress).Should(Equal(teleporterAddress))
 
-	// We pass the block number to the call options because the Fuji C-chain endpoint is load balanced,
-	// and between consecutive calls we might be reaching different nodes with different states.
-	isPaused, err = exampleMessenger.IsTeleporterAddressPaused(&bind.CallOpts{BlockNumber: blockNum}, teleporterAddress)
+	isPaused, err = exampleMessenger.IsTeleporterAddressPaused(&bind.CallOpts{}, teleporterAddress)
 	Expect(err).Should(BeNil())
 	Expect(isPaused).Should(BeTrue())
 
@@ -98,14 +95,11 @@ func CheckUpgradeAccess(network interfaces.Network) {
 	tx, err = exampleMessenger.UnpauseTeleporterAddress(nonOwnerOpts, teleporterAddress)
 	Expect(err).Should(BeNil())
 	receipt = utils.WaitForTransactionSuccess(ctx, subnetInfo, tx.Hash())
-	blockNum = receipt.BlockNumber
 	unpauseTeleporterEvent, err := utils.GetEventFromLogs(receipt.Logs, exampleMessenger.ParseTeleporterAddressUnpaused)
 	Expect(err).Should(BeNil())
 	Expect(unpauseTeleporterEvent.TeleporterAddress).Should(Equal(teleporterAddress))
 
-	// We pass the block number to the call options because the Fuji C-chain endpoint is load balanced,
-	// and between consecutive calls we might be reaching different nodes with different states.
-	isPaused, err = exampleMessenger.IsTeleporterAddressPaused(&bind.CallOpts{BlockNumber: blockNum}, teleporterAddress)
+	isPaused, err = exampleMessenger.IsTeleporterAddressPaused(&bind.CallOpts{}, teleporterAddress)
 	Expect(err).Should(BeNil())
 	Expect(isPaused).Should(BeFalse())
 }

--- a/tests/flows/send_specific_receipts.go
+++ b/tests/flows/send_specific_receipts.go
@@ -96,8 +96,8 @@ func SendSpecificReceipts(network interfaces.Network) {
 	// Call send specific receipts to get reward of relaying two messages
 	receipt, messageID := utils.SendSpecifiedReceiptsAndWaitForAcceptance(
 		ctx,
-		subnetAInfo.BlockchainID,
 		subnetBInfo,
+		subnetAInfo.BlockchainID,
 		[][32]byte{messageID1, messageID2},
 		teleportermessenger.TeleporterFeeInfo{
 			FeeTokenAddress: mockTokenAddress,

--- a/tests/local/network_utils.go
+++ b/tests/local/network_utils.go
@@ -39,7 +39,7 @@ func waitForAllValidatorsToAcceptBlock(ctx context.Context, nodeURIs []string, b
 	defer cancel()
 	for i, uri := range nodeURIs {
 		chainAWSURI := utils.HttpToWebsocketURI(uri, blockchainID.String())
-		log.Info("Creating ethclient for blockchain", "blockchainID", blockchainID.String(), "wsURI", chainAWSURI)
+		log.Debug("Creating ethclient for blockchain", "blockchainID", blockchainID.String(), "wsURI", chainAWSURI)
 		client, err := ethclient.Dial(chainAWSURI)
 		Expect(err).Should(BeNil())
 		defer client.Close()
@@ -49,7 +49,7 @@ func waitForAllValidatorsToAcceptBlock(ctx context.Context, nodeURIs []string, b
 			block, err := client.BlockByNumber(cctx, nil)
 			Expect(err).Should(BeNil())
 			if block.NumberU64() >= height {
-				log.Info("client accepted the block containing SendWarpMessage", "client", i, "height", block.NumberU64())
+				log.Debug("Client accepted the block containing SendWarpMessage", "client", i, "height", block.NumberU64())
 				break
 			}
 		}

--- a/tests/testnet/network.go
+++ b/tests/testnet/network.go
@@ -346,12 +346,14 @@ func (n *testNetwork) getMessageDeliveryTransactionReceipt(
 	}
 
 	if len(logs) == 0 {
-		return nil, errors.New("Failed to find ReceiveCrossChainMessage log for relayed message")
+		return nil, errors.New("failed to find ReceiveCrossChainMessage log for relayed message")
 	} else if len(logs) > 1 {
-		return nil, errors.New("Found multiple ReceiveCrossChainMessage logs for relayed message")
+		return nil, errors.New("found multiple ReceiveCrossChainMessage logs for relayed message")
 	}
 
-	return destination.RPCClient.TransactionReceipt(ctx, logs[0].TxHash)
+	// The transaction should already be mined, but WaitMined will also wait for the eth_blockNumber
+	// endpoint to refelct the block that the transaction has been included in.
+	return utils.WaitMined(ctx, destination.RPCClient, logs[0].TxHash)
 }
 
 func (n *testNetwork) GetSignedMessage(

--- a/tests/testnet/network.go
+++ b/tests/testnet/network.go
@@ -352,7 +352,7 @@ func (n *testNetwork) getMessageDeliveryTransactionReceipt(
 	}
 
 	// The transaction should already be mined, but WaitMined will also wait for the eth_blockNumber
-	// endpoint to refelct the block that the transaction has been included in.
+	// endpoint to reflect the block that the transaction has been included in.
 	return utils.WaitMined(ctx, destination.RPCClient, logs[0].TxHash)
 }
 

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -588,7 +588,7 @@ func WaitMined(ctx context.Context, rpcClient ethclient.Client, txHash common.Ha
 		if currentBlockNumber >= receipt.BlockNumber.Uint64() {
 			return receipt, nil
 		} else {
-			log.Info("Waiting for block height where transaction was included", "txHash",
+			log.Debug("Waiting for block height where transaction was included", "txHash",
 				receipt.TxHash, "blockNumber",
 				receipt.BlockNumber.Uint64())
 		}

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -133,15 +133,12 @@ func RedeemRelayerRewardsAndConfirm(
 	)
 	Expect(err).Should(BeNil())
 	receipt := WaitForTransactionSuccess(ctx, subnet, tx.Hash())
-	log.Info("redeem rewards transaction", "receipt", receipt)
 
 	// Check that the ERC20 balance was incremented
 	balanceAfterRedemption, err := feeToken.BalanceOf(
 		&bind.CallOpts{}, redeemerAddress,
 	)
 	Expect(err).Should(BeNil())
-	log.Info("Original balance", "amount", balanceBeforeRedemption.String())
-	log.Info("New balance", "amount", balanceAfterRedemption.String())
 	Expect(balanceAfterRedemption).Should(
 		Equal(
 			big.NewInt(0).Add(
@@ -591,7 +588,9 @@ func WaitMined(ctx context.Context, rpcClient ethclient.Client, txHash common.Ha
 		if currentBlockNumber >= receipt.BlockNumber.Uint64() {
 			return receipt, nil
 		} else {
-			log.Info("Waiting for block height transaction was included in", "txHash", receipt.TxHash, "blockNumber", receipt.BlockNumber.Uint64())
+			log.Info("Waiting for block height where transaction was included", "txHash",
+				receipt.TxHash, "blockNumber",
+				receipt.BlockNumber.Uint64())
 		}
 
 		// Wait for the next round.


### PR DESCRIPTION
## Why this should be merged

Makes the E2E tests more robust when run against a live testnet.

## How this works

- Adds an extra wait condition in `waitMined` that checks that the `eth_blockNumber` RPC returns a block height at least as high as the block that the transaction was mined in. The `eth_blockNumber` RPC for endpoints behind a public load balancer are configured to return the lowest value that any node behind the load balancer is currently at. This means that subsequent RPC requests should all have seen the state update.
- Removes an unnecessary new client creation in `TraceTransaction`
- Fixes bugs in the `add_fee_amount` and `basic_send_receive` flows when run against a live testnet regarding how receipts are handled. Existing networks have prior receipt queue state, and cannot be relied on to return specific receipts in specific messages.
- Removes an unnecessary `bind.Opts` setting that did not have the proper functionality.

## How this was tested

Running the tests against the Fuji C-Chain, Dispatch, and Echo.

## How is this documented

N/A