### PR TITLE
Fix workflows for branches with "/"

### DIFF
--- a/.github/workflows/abi_bindings_checker.yml
+++ b/.github/workflows/abi_bindings_checker.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - "**"
 
 jobs:
   abi_binding:

--- a/.github/workflows/gomod_checker.yml
+++ b/.github/workflows/gomod_checker.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - "**"
 
 jobs:
   gomod_check:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - "**"
 
 jobs:
   solhint:

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - "**"
 
 jobs:
   slither-analyze:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - "**"
 
 jobs:
   solidity-unit-tests:


### PR DESCRIPTION
## Why this should be merged
Fixes workflows so that PRs with a target branch that has a "/" in them will run.

## How this works
`"*"` does not match branches with `/` in them, but `"**"` does.

PRs match the workflow branch by which branch they're targeting, which is usually `main`, so this is fine, but opening a PR targeted at a branch with a '/' will not currently run these workflows.