### PR TITLE
Remove DeriveEVMContractAddress in favor of crypto.CreateAddress

### DIFF
--- a/tests/flows/deliver_to_nonexistent_contract.go
+++ b/tests/flows/deliver_to_nonexistent_contract.go
@@ -8,7 +8,6 @@ import (
 	examplecrosschainmessenger "github.com/ava-labs/teleporter/abi-bindings/go/CrossChainApplications/examples/ExampleMessenger/ExampleCrossChainMessenger"
 	"github.com/ava-labs/teleporter/tests/interfaces"
 	"github.com/ava-labs/teleporter/tests/utils"
-	deploymentUtils "github.com/ava-labs/teleporter/utils/deployment-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -51,8 +50,7 @@ func DeliverToNonExistentContract(network interfaces.Network) {
 	// Derive the eventual address of the destination contract on Subnet B
 	nonce, err := subnetBInfo.RPCClient.NonceAt(ctx, deployerAddress, nil)
 	Expect(err).Should(BeNil())
-	destinationContractAddress, err := deploymentUtils.DeriveEVMContractAddress(deployerAddress, nonce)
-	Expect(err).Should(BeNil())
+	destinationContractAddress := crypto.CreateAddress(deployerAddress, nonce)
 
 	//
 	// Call the example messenger contract on Subnet A

--- a/tests/flows/erc20_to_native_token_bridge.go
+++ b/tests/flows/erc20_to_native_token_bridge.go
@@ -12,7 +12,6 @@ import (
 	exampleerc20 "github.com/ava-labs/teleporter/abi-bindings/go/Mocks/ExampleERC20"
 	"github.com/ava-labs/teleporter/tests/interfaces"
 	"github.com/ava-labs/teleporter/tests/utils"
-	deploymentUtils "github.com/ava-labs/teleporter/utils/deployment-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -53,11 +52,9 @@ func ERC20ToNativeTokenBridge(network interfaces.LocalNetwork) {
 	// Info we need to calculate for the test
 	deployerPK, err := crypto.HexToECDSA(deployerKeyStr)
 	Expect(err).Should(BeNil())
-	bridgeContractAddress, err := deploymentUtils.DeriveEVMContractAddress(deployerAddress, 0)
-	Expect(err).Should(BeNil())
+	bridgeContractAddress := crypto.CreateAddress(deployerAddress, 0)
 	log.Info("Native Token Bridge Contract Address: " + bridgeContractAddress.Hex())
-	exampleERC20ContractAddress, err := deploymentUtils.DeriveEVMContractAddress(deployerAddress, 1)
-	Expect(err).Should(BeNil())
+	exampleERC20ContractAddress := crypto.CreateAddress(deployerAddress, 1)
 	log.Info("Example ERC20 Contract Address: " + exampleERC20ContractAddress.Hex())
 
 	{

--- a/tests/flows/native_token_bridge.go
+++ b/tests/flows/native_token_bridge.go
@@ -11,7 +11,6 @@ import (
 	nativetokensource "github.com/ava-labs/teleporter/abi-bindings/go/CrossChainApplications/examples/NativeTokenBridge/NativeTokenSource"
 	"github.com/ava-labs/teleporter/tests/interfaces"
 	"github.com/ava-labs/teleporter/tests/utils"
-	deploymentUtils "github.com/ava-labs/teleporter/utils/deployment-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -53,8 +52,7 @@ func NativeTokenBridge(network interfaces.LocalNetwork) {
 	// Info we need to calculate for the test
 	deployerPK, err := crypto.HexToECDSA(deployerKeyStr)
 	Expect(err).Should(BeNil())
-	bridgeContractAddress, err := deploymentUtils.DeriveEVMContractAddress(deployerAddress, 0)
-	Expect(err).Should(BeNil())
+	bridgeContractAddress := crypto.CreateAddress(deployerAddress, 0)
 	log.Info("Native Token Bridge Contract Address: " + bridgeContractAddress.Hex())
 
 	{

--- a/utils/contract-deployment/contractDeploymentTools.go
+++ b/utils/contract-deployment/contractDeploymentTools.go
@@ -11,6 +11,7 @@ import (
 
 	deploymentUtils "github.com/ava-labs/teleporter/utils/deployment-utils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func main() {
@@ -45,10 +46,7 @@ func main() {
 			log.Panic("Failed to parse nonce as uint", err)
 		}
 
-		resultAddress, err := deploymentUtils.DeriveEVMContractAddress(deployerAddress, nonce)
-		if err != nil {
-			log.Panic("Failed to derive contract address.", err)
-		}
+		resultAddress := crypto.CreateAddress(deployerAddress, nonce)
 		fmt.Println(resultAddress.Hex())
 	default:
 		log.Panic("Invalid command type. Supported options are \"constructKeylessTx\" and \"deriveContractAddress\".")


### PR DESCRIPTION
## Why this should be merged

Removes `deploymentUtils.DeriveEVMContractAddress`, which duplicated the functionality of `crypto.CreateAddress`. Thanks to @feuGeneA for first uncovering this [here](https://github.com/ava-labs/teleporter-token-bridge/pull/85#discussion_r1579722712).

## How this works
Self-explanatory 

## How this was tested
Unit tests / CI

## How is this documented
N/A