### PR TITLE
Update gas estimate for receiveCrossChainMessage

### DIFF
--- a/tests/flows/relayer_modifies_message.go
+++ b/tests/flows/relayer_modifies_message.go
@@ -80,6 +80,7 @@ func relayAlteredMessage(
 	signedTx := createAlteredReceiveCrossChainMessageTransaction(
 		ctx,
 		signedWarpMessage,
+		&sendEvent.Message,
 		sendEvent.Message.RequiredGasLimit,
 		network.GetTeleporterContractAddress(),
 		fundedKey,
@@ -93,6 +94,7 @@ func relayAlteredMessage(
 func createAlteredReceiveCrossChainMessageTransaction(
 	ctx context.Context,
 	signedMessage *avalancheWarp.Message,
+	teleporterMesage *teleportermessenger.TeleporterMessage,
 	requiredGasLimit *big.Int,
 	teleporterContractAddress common.Address,
 	fundedKey *ecdsa.PrivateKey,
@@ -105,7 +107,12 @@ func createAlteredReceiveCrossChainMessageTransaction(
 	numSigners, err := signedMessage.Signature.NumSigners()
 	Expect(err).Should(BeNil())
 
-	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(numSigners, requiredGasLimit, len(signedMessage.Bytes()))
+	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(
+		numSigners,
+		requiredGasLimit,
+		len(signedMessage.Bytes()),
+		teleporterMesage,
+	)
 	Expect(err).Should(BeNil())
 
 	callData, err := teleportermessenger.PackReceiveCrossChainMessage(0, fundedAddress)

--- a/tests/flows/relayer_modifies_message.go
+++ b/tests/flows/relayer_modifies_message.go
@@ -94,7 +94,7 @@ func relayAlteredMessage(
 func createAlteredReceiveCrossChainMessageTransaction(
 	ctx context.Context,
 	signedMessage *avalancheWarp.Message,
-	teleporterMesage *teleportermessenger.TeleporterMessage,
+	teleporterMessage *teleportermessenger.TeleporterMessage,
 	requiredGasLimit *big.Int,
 	teleporterContractAddress common.Address,
 	fundedKey *ecdsa.PrivateKey,
@@ -111,7 +111,8 @@ func createAlteredReceiveCrossChainMessageTransaction(
 		numSigners,
 		requiredGasLimit,
 		len(signedMessage.Bytes()),
-		*teleporterMesage,
+		len(signedMessage.Payload),
+		len(teleporterMessage.Receipts),
 	)
 	Expect(err).Should(BeNil())
 

--- a/tests/flows/relayer_modifies_message.go
+++ b/tests/flows/relayer_modifies_message.go
@@ -105,7 +105,7 @@ func createAlteredReceiveCrossChainMessageTransaction(
 	numSigners, err := signedMessage.Signature.NumSigners()
 	Expect(err).Should(BeNil())
 
-	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(numSigners, requiredGasLimit)
+	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(numSigners, requiredGasLimit, len(signedMessage.Bytes()))
 	Expect(err).Should(BeNil())
 
 	callData, err := teleportermessenger.PackReceiveCrossChainMessage(0, fundedAddress)

--- a/tests/flows/relayer_modifies_message.go
+++ b/tests/flows/relayer_modifies_message.go
@@ -111,7 +111,7 @@ func createAlteredReceiveCrossChainMessageTransaction(
 		numSigners,
 		requiredGasLimit,
 		len(signedMessage.Bytes()),
-		teleporterMesage,
+		*teleporterMesage,
 	)
 	Expect(err).Should(BeNil())
 

--- a/tests/local/e2e_test.go
+++ b/tests/local/e2e_test.go
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("[Teleporter integration tests]", func() {
 		})
 
 	// Teleporter tests
-	ginkgo.FIt("Send a message from Subnet A to Subnet B, and one from B to A",
+	ginkgo.It("Send a message from Subnet A to Subnet B, and one from B to A",
 		ginkgo.Label(teleporterMessengerLabel),
 		func() {
 			flows.BasicSendReceive(LocalNetworkInstance)

--- a/tests/local/e2e_test.go
+++ b/tests/local/e2e_test.go
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("[Teleporter integration tests]", func() {
 		})
 
 	// Teleporter tests
-	ginkgo.It("Send a message from Subnet A to Subnet B, and one from B to A",
+	ginkgo.FIt("Send a message from Subnet A to Subnet B, and one from B to A",
 		ginkgo.Label(teleporterMessengerLabel),
 		func() {
 			flows.BasicSendReceive(LocalNetworkInstance)

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -275,7 +275,8 @@ func CreateReceiveCrossChainMessageTransaction(
 		numSigners,
 		requiredGasLimit,
 		len(signedMessage.Bytes()),
-		*teleporterMessage,
+		len(signedMessage.Payload),
+		len(teleporterMessage.Receipts),
 	)
 	Expect(err).Should(BeNil())
 

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -255,38 +255,6 @@ func CreateSendCrossChainMessageTransaction(
 	return SignTransaction(tx, senderKey, source.EVMChainID)
 }
 
-// func CreateRetryMessageExecutionTransaction(
-// 	ctx context.Context,
-// 	subnetInfo interfaces.SubnetTestInfo,
-// 	sourceBlockchainID ids.ID,
-// 	message teleportermessenger.TeleporterMessage,
-// 	senderKey *ecdsa.PrivateKey,
-// 	teleporterContractAddress common.Address,
-// ) *types.Transaction {
-// 	data, err := teleportermessenger.PackRetryMessageExecution(sourceBlockchainID, message)
-// 	Expect(err).Should(BeNil())
-
-// 	// TODO: replace with actual number of signers
-// 	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(10, message.RequiredGasLimit)
-// 	Expect(err).Should(BeNil())
-
-// 	gasFeeCap, gasTipCap, nonce := CalculateTxParams(ctx, subnetInfo, PrivateKeyToAddress(senderKey))
-
-// 	// Sign a transaction to the Teleporter contract
-// 	tx := types.NewTx(&types.DynamicFeeTx{
-// 		ChainID:   subnetInfo.EVMChainID,
-// 		Nonce:     nonce,
-// 		To:        &teleporterContractAddress,
-// 		Gas:       gasLimit,
-// 		GasFeeCap: gasFeeCap,
-// 		GasTipCap: gasTipCap,
-// 		Value:     DefaultTeleporterTransactionValue,
-// 		Data:      data,
-// 	})
-
-// 	return SignTransaction(tx, senderKey, subnetInfo.EVMChainID)
-// }
-
 // Constructs a transaction to call receiveCrossChainMessage
 // Returns the signed transaction.
 func CreateReceiveCrossChainMessageTransaction(
@@ -307,7 +275,7 @@ func CreateReceiveCrossChainMessageTransaction(
 		numSigners,
 		requiredGasLimit,
 		len(signedMessage.Bytes()),
-		teleporterMessage,
+		*teleporterMessage,
 	)
 	Expect(err).Should(BeNil())
 

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -255,37 +255,37 @@ func CreateSendCrossChainMessageTransaction(
 	return SignTransaction(tx, senderKey, source.EVMChainID)
 }
 
-func CreateRetryMessageExecutionTransaction(
-	ctx context.Context,
-	subnetInfo interfaces.SubnetTestInfo,
-	sourceBlockchainID ids.ID,
-	message teleportermessenger.TeleporterMessage,
-	senderKey *ecdsa.PrivateKey,
-	teleporterContractAddress common.Address,
-) *types.Transaction {
-	data, err := teleportermessenger.PackRetryMessageExecution(sourceBlockchainID, message)
-	Expect(err).Should(BeNil())
+// func CreateRetryMessageExecutionTransaction(
+// 	ctx context.Context,
+// 	subnetInfo interfaces.SubnetTestInfo,
+// 	sourceBlockchainID ids.ID,
+// 	message teleportermessenger.TeleporterMessage,
+// 	senderKey *ecdsa.PrivateKey,
+// 	teleporterContractAddress common.Address,
+// ) *types.Transaction {
+// 	data, err := teleportermessenger.PackRetryMessageExecution(sourceBlockchainID, message)
+// 	Expect(err).Should(BeNil())
 
-	// TODO: replace with actual number of signers
-	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(10, message.RequiredGasLimit)
-	Expect(err).Should(BeNil())
+// 	// TODO: replace with actual number of signers
+// 	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(10, message.RequiredGasLimit)
+// 	Expect(err).Should(BeNil())
 
-	gasFeeCap, gasTipCap, nonce := CalculateTxParams(ctx, subnetInfo, PrivateKeyToAddress(senderKey))
+// 	gasFeeCap, gasTipCap, nonce := CalculateTxParams(ctx, subnetInfo, PrivateKeyToAddress(senderKey))
 
-	// Sign a transaction to the Teleporter contract
-	tx := types.NewTx(&types.DynamicFeeTx{
-		ChainID:   subnetInfo.EVMChainID,
-		Nonce:     nonce,
-		To:        &teleporterContractAddress,
-		Gas:       gasLimit,
-		GasFeeCap: gasFeeCap,
-		GasTipCap: gasTipCap,
-		Value:     DefaultTeleporterTransactionValue,
-		Data:      data,
-	})
+// 	// Sign a transaction to the Teleporter contract
+// 	tx := types.NewTx(&types.DynamicFeeTx{
+// 		ChainID:   subnetInfo.EVMChainID,
+// 		Nonce:     nonce,
+// 		To:        &teleporterContractAddress,
+// 		Gas:       gasLimit,
+// 		GasFeeCap: gasFeeCap,
+// 		GasTipCap: gasTipCap,
+// 		Value:     DefaultTeleporterTransactionValue,
+// 		Data:      data,
+// 	})
 
-	return SignTransaction(tx, senderKey, subnetInfo.EVMChainID)
-}
+// 	return SignTransaction(tx, senderKey, subnetInfo.EVMChainID)
+// }
 
 // Constructs a transaction to call receiveCrossChainMessage
 // Returns the signed transaction.
@@ -302,7 +302,7 @@ func CreateReceiveCrossChainMessageTransaction(
 	numSigners, err := signedMessage.Signature.NumSigners()
 	Expect(err).Should(BeNil())
 
-	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(numSigners, requiredGasLimit)
+	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(numSigners, requiredGasLimit, len(signedMessage.Bytes()))
 	Expect(err).Should(BeNil())
 
 	callData, err := teleportermessenger.PackReceiveCrossChainMessage(0, PrivateKeyToAddress(senderKey))

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -302,7 +302,13 @@ func CreateReceiveCrossChainMessageTransaction(
 	numSigners, err := signedMessage.Signature.NumSigners()
 	Expect(err).Should(BeNil())
 
-	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(numSigners, requiredGasLimit, len(signedMessage.Bytes()))
+	teleporterMessage := ParseTeleporterMessage(signedMessage.UnsignedMessage)
+	gasLimit, err := gasUtils.CalculateReceiveMessageGasLimit(
+		numSigners,
+		requiredGasLimit,
+		len(signedMessage.Bytes()),
+		teleporterMessage,
+	)
 	Expect(err).Should(BeNil())
 
 	callData, err := teleportermessenger.PackReceiveCrossChainMessage(0, PrivateKeyToAddress(senderKey))
@@ -1122,4 +1128,14 @@ func SetChainConfig(customChainConfigs map[string]string, subnet interfaces.Subn
 	} else {
 		customChainConfigs[subnet.BlockchainID.String()] = chainConfig
 	}
+}
+
+func ParseTeleporterMessage(unsignedMessage avalancheWarp.UnsignedMessage) *teleportermessenger.TeleporterMessage {
+	addressedPayload, err := payload.ParseAddressedCall(unsignedMessage.Payload)
+	Expect(err).Should(BeNil())
+
+	teleporterMessage, err := teleportermessenger.UnpackTeleporterMessage(addressedPayload.Payload)
+	Expect(err).Should(BeNil())
+
+	return teleporterMessage
 }

--- a/utils/gas-utils/gas_utils.go
+++ b/utils/gas-utils/gas_utils.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	ReceiveCrossChainMessageStaticGasCost uint64 = 250_000
-	DecodeGasPerByte                      uint64 = 35
-	TeleporterMessageReceiptGas                  = 2500
+	ReceiveCrossChainMessageBaseGasCost uint64 = 250_000
+	MarkMessageReceiptGasCost           uint64 = 2500
+	DecodeMessageGasCostPerByte         uint64 = 35
 
 	BaseFeeFactor        = 2
 	MaxPriorityFeePerGas = 2500000000 // 2.5 gwei

--- a/utils/gas-utils/gas_utils.go
+++ b/utils/gas-utils/gas_utils.go
@@ -30,7 +30,7 @@ func CalculateReceiveMessageGasLimit(
 	numSigners int,
 	executionRequiredGasLimit *big.Int,
 	numWarpMessageBytes int,
-	teleporterMessage *teleportermessenger.TeleporterMessage) (uint64, error) {
+	teleporterMessage teleportermessenger.TeleporterMessage) (uint64, error) {
 	if !executionRequiredGasLimit.IsUint64() {
 		return 0, errors.New("required gas limit too high")
 	}

--- a/utils/gas-utils/gas_utils.go
+++ b/utils/gas-utils/gas_utils.go
@@ -28,7 +28,7 @@ const (
 // - The size of the Teleporter message included in the Warp message
 // - The number of Teleporter receipts
 // - Base gas cost for {receiveCrossChainMessage} call
-// -The number of validator signatures included in the aggregate signature
+// - The number of validator signatures included in the aggregate signature
 func CalculateReceiveMessageGasLimit(
 	numSigners int,
 	executionRequiredGasLimit *big.Int,

--- a/utils/gas-utils/gas_utils.go
+++ b/utils/gas-utils/gas_utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ReceiveCrossChainMessageStaticGasCost uint64 = 500_000
+	ReceiveCrossChainMessageStaticGasCost uint64 = 200_000
 
 	BaseFeeFactor        = 2
 	MaxPriorityFeePerGas = 2500000000 // 2.5 gwei
@@ -23,13 +23,17 @@ const (
 // depends on the required limit for the message execution, the number of validator signatures
 // included in the aggregate signature, the static gas cost defined by the precompile, and an
 // extra buffer amount defined here to ensure the call doesn't run out of gas.
-func CalculateReceiveMessageGasLimit(numSigners int, executionRequiredGasLimit *big.Int) (uint64, error) {
+func CalculateReceiveMessageGasLimit(
+	numSigners int,
+	executionRequiredGasLimit *big.Int,
+	numBytes int) (uint64, error) {
 	if !executionRequiredGasLimit.IsUint64() {
 		return 0, errors.New("required gas limit too high")
 	}
 
 	gasAmounts := []uint64{
 		executionRequiredGasLimit.Uint64(),
+		uint64(numBytes) * warp.GasCostPerWarpMessageBytes * 3,
 		ReceiveCrossChainMessageStaticGasCost,
 		uint64(numSigners) * warp.GasCostPerWarpSigner,
 		warp.GasCostPerSignatureVerification,

--- a/utils/gas-utils/gas_utils.go
+++ b/utils/gas-utils/gas_utils.go
@@ -29,7 +29,7 @@ const (
 func CalculateReceiveMessageGasLimit(
 	numSigners int,
 	executionRequiredGasLimit *big.Int,
-	numWarpMessageBytes int,
+	warpMessageSize int,
 	teleporterMessage teleportermessenger.TeleporterMessage) (uint64, error) {
 	if !executionRequiredGasLimit.IsUint64() {
 		return 0, errors.New("required gas limit too high")
@@ -39,12 +39,12 @@ func CalculateReceiveMessageGasLimit(
 		executionRequiredGasLimit.Uint64(),
 		// The variable gas on message bytes is accounted for both when used in predicate verification
 		// and also when used in `getVerifiedWarpMessage`
-		uint64(numWarpMessageBytes) * warp.GasCostPerWarpMessageBytes * 2,
+		uint64(warpMessageSize) * warp.GasCostPerWarpMessageBytes * 2,
 		// Take into the variable gas cost for decoding the Teleporter message
 		// and marking the receipts as received.
-		uint64(len(teleporterMessage.Message)) * DecodeGasPerByte,
-		uint64(len(teleporterMessage.Receipts)) * TeleporterMessageReceiptGas,
-		ReceiveCrossChainMessageStaticGasCost,
+		uint64(len(teleporterMessage.Message)) * DecodeMessageGasCostPerByte,
+		uint64(len(teleporterMessage.Receipts)) * MarkMessageReceiptGasCost,
+		ReceiveCrossChainMessageBaseGasCost,
 		uint64(numSigners) * warp.GasCostPerWarpSigner,
 		warp.GasCostPerSignatureVerification,
 	}


### PR DESCRIPTION
## Why this should be merged
Fixes gas estimate of delivering `receiveCrossChainMessage` call.

## How this works
Previously we just had a static gas constant that was set higher for padding to avoid not having enough gas for delivery. But the gas cost is variable to message size, as well as number of Teleporter receipts included in the message. Now we add those two factors into account for the gas estimate, and also lower the default static gas cost.

## How this was tested
Decode gas cost was tested with a contract that only decodes, then kept passing in one more string character each time, and noticed ~2400 gas increase each time.

Teleporter message receipt gas was through unit test and receiving incrementally more receipts and noticing the increase in gas cost.

CI

## How is this documented
comments