### PR TITLE
Update CODEOWNERS to use @ava-labs/interop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-* @michaelkaplan13 @cam-schultz @minghinmatthewlam @gwen917 @geoff-vball @bernard-avalabs
+* @ava-labs/interop


### PR DESCRIPTION
Update CODEOWNERS to use @ava-labs/interop innstead of enumerating team-members

## How this was tested

Not tested but followed the [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax) and GitHub gives it a `This CODEOWNERS file is valid.` checkmark. 
