### PR TITLE
expose tmpnet dir through local network interface

### DIFF
--- a/tests/interfaces/local_network.go
+++ b/tests/interfaces/local_network.go
@@ -29,4 +29,5 @@ type LocalNetwork interface {
 		fundedKey *ecdsa.PrivateKey,
 		updateNetworkTeleporter bool)
 	GetNetworkID() uint32
+	Dir() string
 }

--- a/tests/local/e2e_test.go
+++ b/tests/local/e2e_test.go
@@ -82,7 +82,7 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	ginkgo.AddReportEntry(
 		"network directory with has node logs & configs; useful in the case of failures",
-		LocalNetworkInstance.tmpnet.Dir,
+		LocalNetworkInstance.Dir(),
 		ginkgo.ReportEntryVisibilityFailureOrVerbose,
 	)
 })

--- a/tests/local/network.go
+++ b/tests/local/network.go
@@ -641,3 +641,7 @@ func (n *LocalNetwork) GetSignedMessage(
 func (n *LocalNetwork) GetNetworkID() uint32 {
 	return n.tmpnet.Genesis.NetworkID
 }
+
+func (n *LocalNetwork) Dir() string {
+	return n.tmpnet.Dir
+}


### PR DESCRIPTION
## Why this should be merged

so it can be used from the awm-relayer tests

## How this was tested

by using it from the awm-relayer tests
