### PR TITLE
Staking manager upgradability

### DIFF
--- a/contracts/staking/NativeTokenStakingManager.sol
+++ b/contracts/staking/NativeTokenStakingManager.sol
@@ -21,10 +21,10 @@ contract NativeTokenStakingManager is Initializable, StakingManager, INativeToke
     /**
      * @notice Begins the validator registration process. Locks the provided native asset in the contract as the stake.
      * @param nodeID The node ID of the validator being registered.
-     * @param registrationExpiry The time at which the reigistration is no longer valid on the P-Chain.
+     * @param registrationExpiry The time at which the registration is no longer valid on the P-Chain.
      * @param signature The raw bytes of the Ed25519 signature over the concatenated bytes of
      * [subnetID]+[nodeID]+[blsPublicKey]+[weight]+[balance]+[expiry]. This signature must correspond to the Ed25519
-     * public key that is used for the nodeID. This approach prevents NodeIDs from being unwillingly added to Subnets.
+     * public key that is used for the nodeID. This approach prevents nodeIDs from being unwillingly added to Subnets.
      * balance is the minimum initial $nAVAX balance that must be attached to the validator serialized as a uint64.
      * The signature field will be validated by the P-Chain. Implementations may choose to validate that the signature
      * field is well-formed but it is not required.

--- a/contracts/staking/NativeTokenStakingManager.sol
+++ b/contracts/staking/NativeTokenStakingManager.sol
@@ -8,9 +8,16 @@ pragma solidity 0.8.25;
 import {INativeTokenStakingManager} from "./interfaces/INativeTokenStakingManager.sol";
 import {Address} from "@openzeppelin/contracts@5.0.2/utils/Address.sol";
 import {StakingManager} from "./StakingManager.sol";
+import {Initializable} from
+    "@openzeppelin/contracts-upgradeable@5.0.2/proxy/utils/Initializable.sol";
 
-contract NativeTokenStakingManager is StakingManager, INativeTokenStakingManager {
+contract NativeTokenStakingManager is Initializable, StakingManager, INativeTokenStakingManager {
     using Address for address payable;
+
+    constructor() {
+        _disableInitializers();
+    }
+
     /**
      * @notice Begins the validator registration process. Locks the provided native asset in the contract as the stake.
      * @param nodeID The node ID of the validator being registered.
@@ -22,7 +29,6 @@ contract NativeTokenStakingManager is StakingManager, INativeTokenStakingManager
      * The signature field will be validated by the P-Chain. Implementations may choose to validate that the signature
      * field is well-formed but it is not required.
      */
-
     function initializeValidatorRegistration(
         bytes32 nodeID,
         uint64 registrationExpiry,

--- a/contracts/staking/StakingManager.sol
+++ b/contracts/staking/StakingManager.sol
@@ -112,6 +112,7 @@ abstract contract StakingManager is
         __StakingManager_init(settings);
     }
 
+    // solhint-disable-next-line func-name-mixedcase
     function __StakingManager_init(StakingManagerSettings calldata settings)
         internal
         onlyInitializing
@@ -121,6 +122,7 @@ abstract contract StakingManager is
         __StakingManager_init_unchained(settings);
     }
 
+    // solhint-disable-next-line func-name-mixedcase
     function __StakingManager_init_unchained(StakingManagerSettings calldata settings)
         internal
         onlyInitializing

--- a/contracts/staking/StakingManager.sol
+++ b/contracts/staking/StakingManager.sol
@@ -74,9 +74,9 @@ abstract contract StakingManager is
 
     // solhint-enable private-vars-leading-underscore
     // keccak256(abi.encode(uint256(keccak256("avalanche-icm.storage.StakingManager")) - 1)) & ~bytes32(uint256(0xff));
-    // TODO: Update to correct storage slot
+    // TODO: Unit test for storage slot
     bytes32 private constant _STAKING_MANAGER_STORAGE_LOCATION =
-        0x8568826440873e37a96cb0aab773b28d8154d963d2f0e41bd9b5c15f63625f91;
+        0xafe6c4731b852fc2be89a0896ae43d22d8b24989064d841b2a1586b4d39ab600;
 
     // solhint-disable ordering
     function _getStakingManagerStorage() private pure returns (StakingManagerStorage storage $) {


### PR DESCRIPTION
## Why this should be merged
Fixes #473 

## How this works
Calls the parent contract's `init` functions
makes Warp messenger a constant
Adds `Initializable` and checks around `initializer` functions
