### PR TITLE
Erc20 staking

### DIFF
--- a/contracts/staking/ERC20TokenStakingManager.sol
+++ b/contracts/staking/ERC20TokenStakingManager.sol
@@ -12,6 +12,7 @@ import {Initializable} from
 import {IERC20} from "@openzeppelin/contracts@5.0.2/token/ERC20/IERC20.sol";
 import {SafeERC20TransferFrom} from "@utilities/SafeERC20TransferFrom.sol";
 import {SafeERC20} from "@openzeppelin/contracts@5.0.2/token/ERC20/utils/SafeERC20.sol";
+import {ICMInitializable} from "../utilities/ICMInitializable.sol";
 
 contract ERC20TokenStakingManager is Initializable, StakingManager, IERC20TokenStakingManager {
     using SafeERC20 for IERC20;
@@ -42,8 +43,10 @@ contract ERC20TokenStakingManager is Initializable, StakingManager, IERC20TokenS
         }
     }
 
-    constructor() {
-        _disableInitializers();
+    constructor(ICMInitializable init) {
+        if (init == ICMInitializable.Disallowed) {
+            _disableInitializers();
+        }
     }
 
     function initialize(

--- a/contracts/staking/ERC20TokenStakingManager.sol
+++ b/contracts/staking/ERC20TokenStakingManager.sol
@@ -1,0 +1,75 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.25;
+
+import {IERC20TokenStakingManager} from "./interfaces/IERC20TokenStakingManager.sol";
+import {StakingManager, StakingManagerSettings} from "./StakingManager.sol";
+import {Initializable} from
+    "@openzeppelin/contracts-upgradeable@5.0.2/proxy/utils/Initializable.sol";
+import {IERC20} from "@openzeppelin/contracts@5.0.2/token/ERC20/IERC20.sol";
+import {SafeERC20TransferFrom} from "@utilities/SafeERC20TransferFrom.sol";
+import {SafeERC20} from "@openzeppelin/contracts@5.0.2/token/ERC20/utils/SafeERC20.sol";
+
+contract ERC20TokenStakingManager is Initializable, StakingManager, IERC20TokenStakingManager {
+    using SafeERC20 for IERC20;
+    using SafeERC20TransferFrom for IERC20;
+
+    // solhint-disable private-vars-leading-underscore
+    /// @custom:storage-location erc7201:avalanche-icm.storage.ERC20TokenStakingManager
+
+    struct ERC20TokenStakingManagerStorage {
+        IERC20 _token;
+    }
+    // solhint-enable private-vars-leading-underscore
+
+    // keccak256(abi.encode(uint256(keccak256("avalanche-icm.storage.ERC20TokenStakingManager")) - 1)) & ~bytes32(uint256(0xff));
+    // TODO: Update to correct storage slot
+    bytes32 private constant _ERC20_STAKING_MANAGER_STORAGE_LOCATION =
+        0x8568826440873e37a96cb0aab773b28d8154d963d2f0e41bd9b5c15f63625f91;
+
+    // solhint-disable ordering
+    function _getERC20StakingManagerStorage()
+        private
+        pure
+        returns (ERC20TokenStakingManagerStorage storage $)
+    {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            $.slot := _ERC20_STAKING_MANAGER_STORAGE_LOCATION
+        }
+    }
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        StakingManagerSettings calldata settings,
+        IERC20 token
+    ) external initializer {
+        initialize(settings);
+        require(address(token) != address(0), "ERC20TokenStakingManager: zero token address");
+        _getERC20StakingManagerStorage()._token = token;
+    }
+
+    function initializeValidatorRegistration(
+        uint256 stakeAmount,
+        bytes32 nodeID,
+        uint64 registrationExpiry,
+        bytes memory signature
+    ) external override returns (bytes32 validationID) {
+        return _initializeValidatorRegistration(nodeID, stakeAmount, registrationExpiry, signature);
+    }
+
+    // Must be guarded with reentrancy guard for safe transfer from
+    function _lock(uint256 value) internal virtual override returns (uint256) {
+        return _getERC20StakingManagerStorage()._token.safeTransferFrom(value);
+    }
+
+    function _unlock(uint256 value, address to) internal virtual override {
+        _getERC20StakingManagerStorage()._token.safeTransfer(to, value);
+    }
+}

--- a/contracts/staking/ERC20TokenStakingManager.sol
+++ b/contracts/staking/ERC20TokenStakingManager.sol
@@ -48,18 +48,16 @@ contract ERC20TokenStakingManager is Initializable, StakingManager, IERC20TokenS
 
     function initialize(
         StakingManagerSettings calldata settings,
-        IERC20 token,
-        uint8 tokenDecimals
+        IERC20 token
     ) external initializer {
-        __ERC20TokenStakingManager_init(settings, token, tokenDecimals);
+        __ERC20TokenStakingManager_init(settings, token);
     }
 
     function __ERC20TokenStakingManager_init(
         StakingManagerSettings calldata settings,
-        IERC20 token,
-        uint8 tokenDecimals
+        IERC20 token
     ) internal onlyInitializing {
-        __StakingManager_init(settings, tokenDecimals);
+        __StakingManager_init(settings);
         __ERC20TokenStakingManager_init_unchained(token);
     }
 

--- a/contracts/staking/ERC20TokenStakingManager.sol
+++ b/contracts/staking/ERC20TokenStakingManager.sol
@@ -19,9 +19,9 @@ contract ERC20TokenStakingManager is Initializable, StakingManager, IERC20TokenS
 
     // solhint-disable private-vars-leading-underscore
     /// @custom:storage-location erc7201:avalanche-icm.storage.ERC20TokenStakingManager
-
     struct ERC20TokenStakingManagerStorage {
         IERC20 _token;
+        uint8 _tokenDecimals;
     }
     // solhint-enable private-vars-leading-underscore
 
@@ -48,11 +48,25 @@ contract ERC20TokenStakingManager is Initializable, StakingManager, IERC20TokenS
 
     function initialize(
         StakingManagerSettings calldata settings,
-        IERC20 token
+        IERC20 token,
+        uint8 tokenDecimals
     ) external initializer {
-        initialize(settings);
+        __ERC20TokenStakingManager_init(settings, token, tokenDecimals);
+    }
+
+    function __ERC20TokenStakingManager_init(
+        StakingManagerSettings calldata settings,
+        IERC20 token,
+        uint8 tokenDecimals
+    ) internal onlyInitializing {
+        __StakingManager_init(settings, tokenDecimals);
+        __ERC20TokenStakingManager_init_unchained(token);
+    }
+
+    function __ERC20TokenStakingManager_init_unchained(IERC20 token) internal onlyInitializing {
+        ERC20TokenStakingManagerStorage storage $ = _getERC20StakingManagerStorage();
         require(address(token) != address(0), "ERC20TokenStakingManager: zero token address");
-        _getERC20StakingManagerStorage()._token = token;
+        $._token = token;
     }
 
     function initializeValidatorRegistration(

--- a/contracts/staking/ERC20TokenStakingManager.sol
+++ b/contracts/staking/ERC20TokenStakingManager.sol
@@ -53,6 +53,7 @@ contract ERC20TokenStakingManager is Initializable, StakingManager, IERC20TokenS
         __ERC20TokenStakingManager_init(settings, token);
     }
 
+    // solhint-disable func-name-mixedcase
     function __ERC20TokenStakingManager_init(
         StakingManagerSettings calldata settings,
         IERC20 token
@@ -61,6 +62,7 @@ contract ERC20TokenStakingManager is Initializable, StakingManager, IERC20TokenS
         __ERC20TokenStakingManager_init_unchained(token);
     }
 
+    // solhint-disable func-name-mixedcase
     function __ERC20TokenStakingManager_init_unchained(IERC20 token) internal onlyInitializing {
         ERC20TokenStakingManagerStorage storage $ = _getERC20StakingManagerStorage();
         require(address(token) != address(0), "ERC20TokenStakingManager: zero token address");

--- a/contracts/staking/NativeTokenStakingManager.sol
+++ b/contracts/staking/NativeTokenStakingManager.sol
@@ -7,7 +7,7 @@ pragma solidity 0.8.25;
 
 import {INativeTokenStakingManager} from "./interfaces/INativeTokenStakingManager.sol";
 import {Address} from "@openzeppelin/contracts@5.0.2/utils/Address.sol";
-import {StakingManager} from "./StakingManager.sol";
+import {StakingManager, StakingManagerSettings} from "./StakingManager.sol";
 import {Initializable} from
     "@openzeppelin/contracts-upgradeable@5.0.2/proxy/utils/Initializable.sol";
 
@@ -17,6 +17,19 @@ contract NativeTokenStakingManager is Initializable, StakingManager, INativeToke
     constructor() {
         _disableInitializers();
     }
+
+    function initialize(StakingManagerSettings calldata settings) external initializer {
+        __NativeTokenStakingManager_init(settings);
+    }
+
+    function __NativeTokenStakingManager_init(StakingManagerSettings calldata settings)
+        internal
+        onlyInitializing
+    {
+        __StakingManager_init(settings, 12);
+    }
+
+    function __NativeTokenStakingManager_init_unchained() internal onlyInitializing {}
 
     /**
      * @notice Begins the validator registration process. Locks the provided native asset in the contract as the stake.

--- a/contracts/staking/NativeTokenStakingManager.sol
+++ b/contracts/staking/NativeTokenStakingManager.sol
@@ -36,7 +36,6 @@ contract NativeTokenStakingManager is Initializable, StakingManager, INativeToke
 
     // solhint-disable-next-line func-name-mixedcase, no-empty-blocks
     function __NativeTokenStakingManager_init_unchained() internal onlyInitializing {}
-    // solhint-enable ordering
 
     /**
      * @notice Begins the validator registration process. Locks the provided native asset in the contract as the stake.
@@ -56,6 +55,7 @@ contract NativeTokenStakingManager is Initializable, StakingManager, INativeToke
     ) external payable returns (bytes32) {
         return _initializeValidatorRegistration(nodeID, msg.value, registrationExpiry, signature);
     }
+    // solhint-enable ordering
 
     function _lock(uint256 value) internal virtual override returns (uint256) {
         return value;

--- a/contracts/staking/NativeTokenStakingManager.sol
+++ b/contracts/staking/NativeTokenStakingManager.sol
@@ -18,18 +18,22 @@ contract NativeTokenStakingManager is Initializable, StakingManager, INativeToke
         _disableInitializers();
     }
 
+    // solhint-disable ordering
     function initialize(StakingManagerSettings calldata settings) external initializer {
         __NativeTokenStakingManager_init(settings);
     }
 
+    // solhint-disable-next-line func-name-mixedcase
     function __NativeTokenStakingManager_init(StakingManagerSettings calldata settings)
         internal
         onlyInitializing
     {
-        __StakingManager_init(settings, 12);
+        __StakingManager_init(settings);
     }
 
+    // solhint-disable-next-line func-name-mixedcase, no-empty-blocks
     function __NativeTokenStakingManager_init_unchained() internal onlyInitializing {}
+    // solhint-enable ordering
 
     /**
      * @notice Begins the validator registration process. Locks the provided native asset in the contract as the stake.

--- a/contracts/staking/StakingManager.sol
+++ b/contracts/staking/StakingManager.sol
@@ -63,7 +63,6 @@ abstract contract StakingManager is
         IRewardCalculator _rewardCalculator;
         uint8 _maximumHourlyChurn;
         ValidatorChurnPeriod _churnTracker;
-        uint8 _tokenDecimals;
         // Maps the validationID to the registration message such that the message can be re-sent if needed.
         mapping(bytes32 => bytes) _pendingRegisterValidationMessages;
         // Maps the validationID to the validator information.
@@ -93,20 +92,20 @@ abstract contract StakingManager is
         IWarpMessenger(0x0200000000000000000000000000000000000005);
 
     // solhint-disable-next-line func-name-mixedcase
-    function __StakingManager_init(
-        StakingManagerSettings calldata settings,
-        uint8 tokenDecimals
-    ) internal onlyInitializing {
+    function __StakingManager_init(StakingManagerSettings calldata settings)
+        internal
+        onlyInitializing
+    {
         __ReentrancyGuard_init();
         __Context_init();
-        __StakingManager_init_unchained(settings, tokenDecimals);
+        __StakingManager_init_unchained(settings);
     }
 
     // solhint-disable-next-line func-name-mixedcase
-    function __StakingManager_init_unchained(
-        StakingManagerSettings calldata settings,
-        uint8 tokenDecimals
-    ) internal onlyInitializing {
+    function __StakingManager_init_unchained(StakingManagerSettings calldata settings)
+        internal
+        onlyInitializing
+    {
         StakingManagerStorage storage $ = _getStakingManagerStorage();
         $._pChainBlockchainID = settings.pChainBlockchainID;
         $._subnetID = settings.subnetID;
@@ -115,7 +114,6 @@ abstract contract StakingManager is
         $._minimumStakeDuration = settings.minimumStakeDuration;
         $._maximumHourlyChurn = settings.maximumHourlyChurn;
         $._rewardCalculator = settings.rewardCalculator;
-        $._tokenDecimals = tokenDecimals;
     }
 
     /**
@@ -157,7 +155,7 @@ abstract contract StakingManager is
         uint256 lockedValue = _lock(value);
 
         // Ensure the stake churn doesn't exceed the maximum churn rate.
-        uint64 weight = _valueToWeight($, lockedValue);
+        uint64 weight = valueToWeightt(lockedValue);
         _checkAndUpdateChurnTracker(weight);
 
         // Ensure the weight is within the valid range.
@@ -422,20 +420,14 @@ abstract contract StakingManager is
         $._churnTracker = churnTracker;
     }
 
+    function valueToWeightt(uint256 value) public pure returns (uint64) {
+        return uint64(value / 1e12);
+    }
+
+    function weightToValuee(uint64 weight) public pure returns (uint256) {
+        return uint256(weight) * 1e12;
+    }
+
     function _lock(uint256 value) internal virtual returns (uint256);
     function _unlock(uint256 value, address to) internal virtual;
-
-    function _valueToWeight(
-        StakingManagerStorage storage $,
-        uint256 value
-    ) private view returns (uint64) {
-        return uint64(value / (10 ** $._tokenDecimals));
-    }
-
-    function _weightToValue(
-        StakingManagerStorage storage $,
-        uint64 weight
-    ) private view returns (uint256) {
-        return uint256(weight) * (10 ** $._tokenDecimals);
-    }
 }

--- a/contracts/staking/StakingManager.sol
+++ b/contracts/staking/StakingManager.sol
@@ -322,7 +322,7 @@ abstract contract StakingManager is
      * @notice Resubmits a validator end message to be sent to P-Chain to the Warp precompile.
      * Only necessary if the original message can't be delivered due to validator churn.
      */
-    // solhint-disable-next-line no-empty-blocks
+    // solhint-disable-next-line
     function resendEndValidatorMessage(bytes32 validationID) external {
         StakingManagerStorage storage $ = _getStakingManagerStorage();
         Validator memory validator = $._validationPeriods[validationID];

--- a/contracts/staking/StakingManager.sol
+++ b/contracts/staking/StakingManager.sol
@@ -155,7 +155,7 @@ abstract contract StakingManager is
         uint256 lockedValue = _lock(value);
 
         // Ensure the stake churn doesn't exceed the maximum churn rate.
-        uint64 weight = valueToWeightt(lockedValue);
+        uint64 weight = valueToWeight(lockedValue);
         _checkAndUpdateChurnTracker(weight);
 
         // Ensure the weight is within the valid range.
@@ -425,11 +425,11 @@ abstract contract StakingManager is
         $._churnTracker = churnTracker;
     }
 
-    function valueToWeightt(uint256 value) public pure returns (uint64) {
+    function valueToWeight(uint256 value) public pure returns (uint64) {
         return uint64(value / 1e12);
     }
 
-    function weightToValuee(uint64 weight) public pure returns (uint256) {
+    function weightToValue(uint64 weight) public pure returns (uint256) {
         return uint256(weight) * 1e12;
     }
 

--- a/contracts/staking/StakingMessages.sol
+++ b/contracts/staking/StakingMessages.sol
@@ -48,7 +48,7 @@ library StakingMessages {
      *                        | 148 bytes |
      *                        +-----------+
      *
-     * @param valiationInfo The information to pack into the message.
+     * @param validationInfo The information to pack into the message.
      * @return The validationID and the packed message.
      */
     function packRegisterSubnetValidatorMessage(ValidationInfo memory validationInfo)

--- a/contracts/staking/StakingMessages.sol
+++ b/contracts/staking/StakingMessages.sol
@@ -48,13 +48,13 @@ library StakingMessages {
      *                        | 148 bytes |
      *                        +-----------+
      */
-    function packRegisterSubnetValidatorMessage(ValidationInfo memory valiationInfo)
+    function packRegisterSubnetValidatorMessage(ValidationInfo memory validationInfo)
         internal
         pure
         returns (bytes32, bytes memory)
     {
         (bytes32 validationID, bytes memory serializedValidationInfo) =
-            packValidationInfo(valiationInfo);
+            packValidationInfo(validationInfo);
 
         bytes memory res = new bytes(148);
         // Pack the message type

--- a/contracts/staking/interfaces/IStakingManager.sol
+++ b/contracts/staking/interfaces/IStakingManager.sol
@@ -5,7 +5,6 @@
 
 pragma solidity 0.8.25;
 
-import {StakingMessages} from "../StakingMessages.sol";
 import {IRewardCalculator} from "./IRewardCalculator.sol";
 
 struct StakingManagerSettings {

--- a/contracts/staking/interfaces/IStakingManager.sol
+++ b/contracts/staking/interfaces/IStakingManager.sol
@@ -5,6 +5,25 @@
 
 pragma solidity 0.8.25;
 
+import {StakingMessages} from "../StakingMessages.sol";
+import {IRewardCalculator} from "./IRewardCalculator.sol";
+
+struct InitialStakerInfo {
+    StakingMessages.ValidationInfo validationInfo;
+    address owner;
+}
+
+struct StakingManagerSettings {
+    bytes32 pChainBlockchainID;
+    bytes32 subnetID;
+    uint256 minimumStakeAmount;
+    uint256 maximumStakeAmount;
+    uint64 minimumStakeDuration;
+    uint8 maximumHourlyChurn;
+    InitialStakerInfo[] initialStakers;
+    IRewardCalculator rewardCalculator;
+}
+
 interface IStakingManager {
     /**
      * @notice Emitted when a new validation period is created by stake being locked in the manager contract.

--- a/contracts/staking/tests/ERC20TokenStakingManagerTests.t.sol
+++ b/contracts/staking/tests/ERC20TokenStakingManagerTests.t.sol
@@ -9,8 +9,6 @@ import {StakingManagerTest} from "./StakingManagerTests.t.sol";
 import {ERC20TokenStakingManager} from "../ERC20TokenStakingManager.sol";
 import {StakingManagerSettings} from "../interfaces/IStakingManager.sol";
 import {IRewardCalculator} from "../interfaces/IRewardCalculator.sol";
-import {IWarpMessenger, WarpMessage} from "../StakingManager.sol";
-import {StakingMessages} from "../StakingMessages.sol";
 import {ICMInitializable} from "../../utilities/ICMInitializable.sol";
 import {ExampleERC20} from "@mocks/ExampleERC20.sol";
 import {IERC20} from "@openzeppelin/contracts@5.0.2/token/ERC20/IERC20.sol";

--- a/contracts/staking/tests/ERC20TokenStakingManagerTests.t.sol
+++ b/contracts/staking/tests/ERC20TokenStakingManagerTests.t.sol
@@ -6,21 +6,28 @@
 pragma solidity 0.8.25;
 
 import {StakingManagerTest} from "./StakingManagerTests.t.sol";
-import {NativeTokenStakingManager} from "../NativeTokenStakingManager.sol";
+import {ERC20TokenStakingManager} from "../ERC20TokenStakingManager.sol";
 import {StakingManagerSettings} from "../interfaces/IStakingManager.sol";
 import {IRewardCalculator} from "../interfaces/IRewardCalculator.sol";
 import {IWarpMessenger, WarpMessage} from "../StakingManager.sol";
 import {StakingMessages} from "../StakingMessages.sol";
 import {ICMInitializable} from "../../utilities/ICMInitializable.sol";
+import {ExampleERC20} from "@mocks/ExampleERC20.sol";
+import {IERC20} from "@openzeppelin/contracts@5.0.2/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts@5.0.2/token/ERC20/utils/SafeERC20.sol";
 
 // TODO: Remove this once all unit tests implemented
 // solhint-disable no-empty-blocks
-contract NativeTokenStakingManagerTest is StakingManagerTest {
-    NativeTokenStakingManager public app;
+contract ERC20TokenStakingManagerTest is StakingManagerTest {
+    using SafeERC20 for IERC20;
+
+    ERC20TokenStakingManager public app;
+    IERC20 public token;
 
     function setUp() public virtual {
         // Construct the object under test
-        app = new NativeTokenStakingManager(ICMInitializable.Allowed);
+        app = new ERC20TokenStakingManager(ICMInitializable.Allowed);
+        token = new ExampleERC20();
         app.initialize(
             StakingManagerSettings({
                 pChainBlockchainID: P_CHAIN_BLOCKCHAIN_ID,
@@ -30,26 +37,24 @@ contract NativeTokenStakingManagerTest is StakingManagerTest {
                 minimumStakeDuration: DEFAULT_MINIMUM_STAKE_DURATION,
                 maximumHourlyChurn: DEFAULT_MAXIMUM_HOURLY_CHURN,
                 rewardCalculator: IRewardCalculator(address(0))
-            })
+            }),
+            token
         );
         stakingManager = app;
     }
 
-    // Helpers
     function _initializeValidatorRegistration(
         bytes32 nodeID,
         uint64 registrationExpiry,
         bytes memory signature,
         uint256 stakeAmount
     ) internal virtual override returns (bytes32) {
-        return app.initializeValidatorRegistration{value: stakeAmount}(
-            nodeID, registrationExpiry, signature
-        );
+        return
+            app.initializeValidatorRegistration(stakeAmount, nodeID, registrationExpiry, signature);
     }
 
     function _beforeSend(uint256 value) internal override {
-        // Native tokens no need pre approve
+        // ERC20 tokens need to be pre-approved
+        token.safeIncreaseAllowance(address(app), value);
     }
 }
-// TODO: Remove this once all unit tests implemented
-// solhint-enable no-empty-blocks

--- a/contracts/staking/tests/NativeTokenStakingManagerTests.t.sol
+++ b/contracts/staking/tests/NativeTokenStakingManagerTests.t.sol
@@ -9,8 +9,6 @@ import {StakingManagerTest} from "./StakingManagerTests.t.sol";
 import {NativeTokenStakingManager} from "../NativeTokenStakingManager.sol";
 import {StakingManagerSettings} from "../interfaces/IStakingManager.sol";
 import {IRewardCalculator} from "../interfaces/IRewardCalculator.sol";
-import {IWarpMessenger, WarpMessage} from "../StakingManager.sol";
-import {StakingMessages} from "../StakingMessages.sol";
 import {ICMInitializable} from "../../utilities/ICMInitializable.sol";
 
 // TODO: Remove this once all unit tests implemented

--- a/contracts/staking/tests/StakingManagerTests.t.sol
+++ b/contracts/staking/tests/StakingManagerTests.t.sol
@@ -10,6 +10,8 @@ import {StakingManager} from "../StakingManager.sol";
 import {StakingMessages} from "../StakingMessages.sol";
 import {IWarpMessenger, WarpMessage} from "../StakingManager.sol";
 
+// TODO: Remove this once all unit tests implemented
+// solhint-disable no-empty-blocks
 abstract contract StakingManagerTest is Test {
     bytes32 public constant P_CHAIN_BLOCKCHAIN_ID =
         bytes32(hex"0000000000000000000000000000000000000000000000000000000000000000");
@@ -346,3 +348,4 @@ abstract contract StakingManagerTest is Test {
 
     function _beforeSend(uint256 value) internal virtual;
 }
+// solhint-enable no-empty-blocks

--- a/contracts/staking/tests/StakingManagerTests.t.sol
+++ b/contracts/staking/tests/StakingManagerTests.t.sol
@@ -7,6 +7,8 @@ pragma solidity 0.8.25;
 
 import {Test} from "@forge-std/Test.sol";
 import {StakingManager} from "../StakingManager.sol";
+import {StakingMessages} from "../StakingMessages.sol";
+import {IWarpMessenger, WarpMessage} from "../StakingManager.sol";
 
 abstract contract StakingManagerTest is Test {
     bytes32 public constant P_CHAIN_BLOCKCHAIN_ID =
@@ -53,6 +55,148 @@ abstract contract StakingManagerTest is Test {
 
     event ValidationPeriodEnded(bytes32 indexed validationID);
 
+    function testInitializeValidatorRegistrationSuccess() public {
+        _setUpInitializeValidatorRegistration(
+            DEFAULT_NODE_ID,
+            DEFAULT_SUBNET_ID,
+            DEFAULT_WEIGHT,
+            DEFAULT_EXPIRY,
+            DEFAULT_ED25519_SIGNATURE
+        );
+    }
+
+    function testInitializeValidatorRegistrationExcessiveChurn() public {
+        // TODO: implement
+    }
+
+    function testInitializeValidatorRegistrationInsufficientStake() public {
+        // TODO: implement
+    }
+
+    function testInitializeValidatorRegistrationExcessiveStake() public {
+        // TODO: implement
+    }
+
+    function testInitializeValidatorRegistrationInsufficientDuration() public {
+        // TODO: implement
+    }
+
+    // The following tests call functions that are  implemented in StakingManager, but access state that's
+    // only set in NativeTokenStakingManager. Therefore we call them via the concrete type, rather than a
+    // reference to the abstract type.
+    function testResendRegisterValidatorMessage() public {
+        bytes32 validationID = _setUpInitializeValidatorRegistration(
+            DEFAULT_NODE_ID,
+            DEFAULT_SUBNET_ID,
+            DEFAULT_WEIGHT,
+            DEFAULT_EXPIRY,
+            DEFAULT_ED25519_SIGNATURE
+        );
+        (, bytes memory registerSubnetValidatorMessage) = StakingMessages
+            .packRegisterSubnetValidatorMessage(
+            StakingMessages.ValidationInfo({
+                subnetID: DEFAULT_SUBNET_ID,
+                nodeID: DEFAULT_NODE_ID,
+                weight: DEFAULT_WEIGHT,
+                registrationExpiry: DEFAULT_EXPIRY,
+                signature: DEFAULT_ED25519_SIGNATURE
+            })
+        );
+        _mockSendWarpMessage(registerSubnetValidatorMessage, bytes32(0));
+        stakingManager.resendRegisterValidatorMessage(validationID);
+    }
+
+    function testCompleteValidatorRegistration() public {
+        _setUpCompleteValidatorRegistration({
+            nodeID: DEFAULT_NODE_ID,
+            subnetID: DEFAULT_SUBNET_ID,
+            weight: DEFAULT_WEIGHT,
+            registrationExpiry: DEFAULT_EXPIRY,
+            signature: DEFAULT_ED25519_SIGNATURE,
+            registrationTimestamp: DEFAULT_REGISTRATION_TIMESTAMP
+        });
+    }
+
+    function testInitializeEndValidation() public {
+        _setUpInitializeEndValidation({
+            nodeID: DEFAULT_NODE_ID,
+            subnetID: DEFAULT_SUBNET_ID,
+            weight: DEFAULT_WEIGHT,
+            registrationExpiry: DEFAULT_EXPIRY,
+            signature: DEFAULT_ED25519_SIGNATURE,
+            registrationTimestamp: DEFAULT_REGISTRATION_TIMESTAMP,
+            completionTimestamp: DEFAULT_COMPLETION_TIMESTAMP
+        });
+    }
+
+    function testInitializeEndValidationWithUptimeProof() public {
+        // TODO: implement
+    }
+
+    function testInitializeEndValidationExcessiveChurn() public {
+        // TODO: implement
+    }
+
+    function testResendEndValidation() public {
+        bytes32 validationID = _setUpInitializeEndValidation({
+            nodeID: DEFAULT_NODE_ID,
+            subnetID: DEFAULT_SUBNET_ID,
+            weight: DEFAULT_WEIGHT,
+            registrationExpiry: DEFAULT_EXPIRY,
+            signature: DEFAULT_ED25519_SIGNATURE,
+            registrationTimestamp: DEFAULT_REGISTRATION_TIMESTAMP,
+            completionTimestamp: DEFAULT_COMPLETION_TIMESTAMP
+        });
+        bytes memory setValidatorWeightPayload =
+            StakingMessages.packSetSubnetValidatorWeightMessage(validationID, 0, 0);
+        _mockSendWarpMessage(setValidatorWeightPayload, bytes32(0));
+        stakingManager.resendEndValidatorMessage(validationID);
+    }
+
+    function testCompleteEndValidation() public {
+        bytes32 validationID = _setUpInitializeEndValidation({
+            nodeID: DEFAULT_NODE_ID,
+            subnetID: DEFAULT_SUBNET_ID,
+            weight: DEFAULT_WEIGHT,
+            registrationExpiry: DEFAULT_EXPIRY,
+            signature: DEFAULT_ED25519_SIGNATURE,
+            registrationTimestamp: DEFAULT_REGISTRATION_TIMESTAMP,
+            completionTimestamp: DEFAULT_COMPLETION_TIMESTAMP
+        });
+
+        bytes memory subnetValidatorRegistrationMessage =
+            StakingMessages.packSubnetValidatorRegistrationMessage(validationID, false);
+
+        _mockGetVerifiedWarpMessage(subnetValidatorRegistrationMessage, true);
+
+        vm.expectEmit(true, true, true, true, address(stakingManager));
+        emit ValidationPeriodEnded(validationID);
+
+        stakingManager.completeEndValidation(0, false);
+    }
+
+    function testCompleteEndValidationSetWeightMessageType() public {
+        bytes32 validationID = _setUpInitializeEndValidation({
+            nodeID: DEFAULT_NODE_ID,
+            subnetID: DEFAULT_SUBNET_ID,
+            weight: DEFAULT_WEIGHT,
+            registrationExpiry: DEFAULT_EXPIRY,
+            signature: DEFAULT_ED25519_SIGNATURE,
+            registrationTimestamp: DEFAULT_REGISTRATION_TIMESTAMP,
+            completionTimestamp: DEFAULT_COMPLETION_TIMESTAMP
+        });
+
+        bytes memory setSubnetValidatorWeightMessage =
+            StakingMessages.packSetSubnetValidatorWeightMessage(validationID, 1, 0);
+
+        _mockGetVerifiedWarpMessage(setSubnetValidatorWeightMessage, true);
+
+        vm.expectEmit(true, true, true, true, address(stakingManager));
+        emit ValidationPeriodEnded(validationID);
+
+        stakingManager.completeEndValidation(0, true);
+    }
+
     function testValueToWeight() public view {
         uint64 w1 = stakingManager.valueToWeight(1e12);
         uint64 w2 = stakingManager.valueToWeight(1e18);
@@ -72,4 +216,133 @@ abstract contract StakingManagerTest is Test {
         assertEq(v2, 1e18);
         assertEq(v3, 1e27);
     }
+
+    function _setUpInitializeValidatorRegistration(
+        bytes32 nodeID,
+        bytes32 subnetID,
+        uint64 weight,
+        uint64 registrationExpiry,
+        bytes memory signature
+    ) internal returns (bytes32 validationID) {
+        (validationID,) = StakingMessages.packValidationInfo(
+            StakingMessages.ValidationInfo({
+                nodeID: nodeID,
+                subnetID: subnetID,
+                weight: weight,
+                registrationExpiry: registrationExpiry,
+                signature: signature
+            })
+        );
+        (, bytes memory registerSubnetValidatorMessage) = StakingMessages
+            .packRegisterSubnetValidatorMessage(
+            StakingMessages.ValidationInfo({
+                subnetID: subnetID,
+                nodeID: nodeID,
+                weight: weight,
+                registrationExpiry: registrationExpiry,
+                signature: signature
+            })
+        );
+        vm.warp(DEFAULT_EXPIRY - 1);
+        _mockSendWarpMessage(registerSubnetValidatorMessage, bytes32(0));
+
+        _beforeSend(stakingManager.weightToValue(weight));
+        vm.expectEmit(true, true, true, true, address(stakingManager));
+        emit ValidationPeriodCreated(
+            validationID, DEFAULT_NODE_ID, bytes32(0), weight, DEFAULT_EXPIRY
+        );
+
+        _initializeValidatorRegistration(
+            nodeID, registrationExpiry, signature, stakingManager.weightToValue(weight)
+        );
+    }
+
+    function _setUpCompleteValidatorRegistration(
+        bytes32 nodeID,
+        bytes32 subnetID,
+        uint64 weight,
+        uint64 registrationExpiry,
+        bytes memory signature,
+        uint64 registrationTimestamp
+    ) internal returns (bytes32 validationID) {
+        validationID = _setUpInitializeValidatorRegistration(
+            nodeID, subnetID, weight, registrationExpiry, signature
+        );
+        bytes memory subnetValidatorRegistrationMessage =
+            StakingMessages.packSubnetValidatorRegistrationMessage(validationID, true);
+
+        _mockGetVerifiedWarpMessage(subnetValidatorRegistrationMessage, true);
+
+        vm.warp(registrationTimestamp);
+        vm.expectEmit(true, true, true, true, address(stakingManager));
+        emit ValidationPeriodRegistered(validationID, weight, registrationTimestamp);
+
+        stakingManager.completeValidatorRegistration(0);
+    }
+
+    function _setUpInitializeEndValidation(
+        bytes32 nodeID,
+        bytes32 subnetID,
+        uint64 weight,
+        uint64 registrationExpiry,
+        bytes memory signature,
+        uint64 registrationTimestamp,
+        uint64 completionTimestamp
+    ) internal returns (bytes32 validationID) {
+        validationID = _setUpCompleteValidatorRegistration({
+            nodeID: nodeID,
+            subnetID: subnetID,
+            weight: weight,
+            registrationExpiry: registrationExpiry,
+            signature: signature,
+            registrationTimestamp: registrationTimestamp
+        });
+
+        vm.warp(completionTimestamp);
+        bytes memory setValidatorWeightPayload =
+            StakingMessages.packSetSubnetValidatorWeightMessage(validationID, 0, 0);
+        _mockSendWarpMessage(setValidatorWeightPayload, bytes32(0));
+        vm.expectEmit(true, true, true, true, address(stakingManager));
+        emit ValidatorRemovalInitialized(validationID, bytes32(0), weight, completionTimestamp, 0);
+
+        stakingManager.initializeEndValidation(validationID, false, 0);
+    }
+
+    function _mockSendWarpMessage(bytes memory payload, bytes32 expectedMessageID) internal {
+        vm.mockCall(
+            WARP_PRECOMPILE_ADDRESS,
+            abi.encode(IWarpMessenger.sendWarpMessage.selector),
+            abi.encode(expectedMessageID)
+        );
+        vm.expectCall(
+            WARP_PRECOMPILE_ADDRESS, abi.encodeCall(IWarpMessenger.sendWarpMessage, payload)
+        );
+    }
+
+    function _mockGetVerifiedWarpMessage(bytes memory expectedPayload, bool valid) internal {
+        vm.mockCall(
+            WARP_PRECOMPILE_ADDRESS,
+            abi.encodeWithSelector(IWarpMessenger.getVerifiedWarpMessage.selector, uint32(0)),
+            abi.encode(
+                WarpMessage({
+                    sourceChainID: P_CHAIN_BLOCKCHAIN_ID,
+                    originSenderAddress: address(0),
+                    payload: expectedPayload
+                }),
+                valid
+            )
+        );
+        vm.expectCall(
+            WARP_PRECOMPILE_ADDRESS, abi.encodeCall(IWarpMessenger.getVerifiedWarpMessage, 0)
+        );
+    }
+
+    function _initializeValidatorRegistration(
+        bytes32 nodeID,
+        uint64 registrationExpiry,
+        bytes memory signature,
+        uint256 stakeAmount
+    ) internal virtual returns (bytes32);
+
+    function _beforeSend(uint256 value) internal virtual;
 }


### PR DESCRIPTION
## Why this should be merged
Fixes #466 

## How this works
- Adds a corresponding `ERC20TokenStakingManager`
- Moves the `initialize` function to the concrete contract implementations
- Adds additional `init` functions
- Staking manager takes in the ERC20 token

## How this was tested
unit tests update
CI

## How is this documented