### PR TITLE
min stake duration fix

### DIFF
--- a/tests/flows/staking/erc20_token_staking.go
+++ b/tests/flows/staking/erc20_token_staking.go
@@ -3,6 +3,7 @@ package staking
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
@@ -31,7 +32,7 @@ func ERC20TokenStakingManager(network interfaces.LocalNetwork) {
 	// Get the subnets info
 	cChainInfo := network.GetPrimaryNetworkInfo()
 	subnetAInfo, _ := utils.GetTwoSubnets(network)
-	_, fundedKey := network.GetFundedAccountInfo()
+	fundedAddress, fundedKey := network.GetFundedAccountInfo()
 	pChainInfo := utils.GetPChainInfo(cChainInfo)
 
 	signatureAggregator := utils.NewSignatureAggregator(
@@ -69,6 +70,19 @@ func ERC20TokenStakingManager(network interfaces.LocalNetwork) {
 		stakingManagerAddress,
 		erc20,
 		stakeAmount,
+	)
+
+	// Make sure minimum stake duration has passed
+	time.Sleep(time.Duration(utils.DefaultMinStakeDurationSeconds) * time.Second)
+
+	// Send a loopback transaction to self to force a block production
+	// before delisting the validator.
+	utils.SendNativeTransfer(
+		context.Background(),
+		subnetAInfo,
+		fundedKey,
+		fundedAddress,
+		big.NewInt(10),
 	)
 
 	//

--- a/tests/flows/staking/native_token_staking.go
+++ b/tests/flows/staking/native_token_staking.go
@@ -3,6 +3,7 @@ package staking
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
@@ -32,7 +33,7 @@ func NativeTokenStakingManager(network interfaces.LocalNetwork) {
 	// Get the subnets info
 	cChainInfo := network.GetPrimaryNetworkInfo()
 	subnetAInfo, _ := utils.GetTwoSubnets(network)
-	_, fundedKey := network.GetFundedAccountInfo()
+	fundedAddress, fundedKey := network.GetFundedAccountInfo()
 	pChainInfo := utils.GetPChainInfo(cChainInfo)
 
 	signatureAggregator := utils.NewSignatureAggregator(
@@ -78,6 +79,19 @@ func NativeTokenStakingManager(network interfaces.LocalNetwork) {
 			stakeAmount,
 		)
 	}
+
+	// Make sure minimum stake duration has passed
+	time.Sleep(time.Duration(utils.DefaultMinStakeDurationSeconds) * time.Second)
+
+	// Send a loopback transaction to self to force a block production
+	// before delisting the validator.
+	utils.SendNativeTransfer(
+		context.Background(),
+		subnetAInfo,
+		fundedKey,
+		fundedAddress,
+		big.NewInt(10),
+	)
 
 	//
 	// Delist the validator

--- a/tests/utils/staking.go
+++ b/tests/utils/staking.go
@@ -609,8 +609,6 @@ func InitializeEndNativeValidation(
 	stakingManager *nativetokenstakingmanager.NativeTokenStakingManager,
 	validationID ids.ID,
 ) *types.Receipt {
-	// Make sure minimum stake duration has passed
-	time.Sleep(time.Duration(DefaultMinStakeDurationSeconds*2) * time.Second)
 	opts, err := bind.NewKeyedTransactorWithChainID(sendingKey, subnet.EVMChainID)
 	Expect(err).Should(BeNil())
 	tx, err := stakingManager.InitializeEndValidation(
@@ -629,8 +627,6 @@ func InitializeEndERC20Validation(
 	stakingManager *erc20tokenstakingmanager.ERC20TokenStakingManager,
 	validationID ids.ID,
 ) *types.Receipt {
-	// Make sure minimum stake duration has passed
-	time.Sleep(time.Duration(DefaultMinStakeDurationSeconds*15) * time.Second)
 	opts, err := bind.NewKeyedTransactorWithChainID(sendingKey, subnet.EVMChainID)
 	Expect(err).Should(BeNil())
 	tx, err := stakingManager.InitializeEndValidation(


### PR DESCRIPTION
## Why this should be merged

This fixes issues with minstakeduration not elapsing by forcing a block production between registration and ending by sending a loopback native transfer tx.

## How this works

## How this was tested

ERC20 and Native e2e tests should now pass. 

## How is this documented