### PR TITLE
Test cleanup

### DIFF
--- a/tests/flows/validator-manager/erc20_delegation.go
+++ b/tests/flows/validator-manager/erc20_delegation.go
@@ -69,6 +69,7 @@ func ERC20Delegation(network interfaces.LocalNetwork) {
 	)
 	Expect(err).Should(BeNil())
 	validationID = utils.InitializeAndCompleteERC20ValidatorRegistration(
+		ctx,
 		network,
 		signatureAggregator,
 		fundedKey,
@@ -96,6 +97,7 @@ func ERC20Delegation(network interfaces.LocalNetwork) {
 		nonce := uint64(1)
 
 		receipt := utils.InitializeERC20DelegatorRegistration(
+			ctx,
 			fundedKey,
 			subnetAInfo,
 			validationID,
@@ -136,6 +138,7 @@ func ERC20Delegation(network interfaces.LocalNetwork) {
 
 		// Deliver the Warp message to the subnet
 		receipt = utils.CompleteERC20DelegatorRegistration(
+			ctx,
 			fundedKey,
 			delegationID,
 			subnetAInfo,
@@ -157,6 +160,7 @@ func ERC20Delegation(network interfaces.LocalNetwork) {
 	{
 		nonce := uint64(2)
 		receipt := utils.InitializeEndERC20Delegation(
+			ctx,
 			fundedKey,
 			subnetAInfo,
 			stakingManager,
@@ -191,6 +195,7 @@ func ERC20Delegation(network interfaces.LocalNetwork) {
 
 		// Deliver the Warp message to the subnet
 		receipt = utils.CompleteEndERC20Delegation(
+			ctx,
 			fundedKey,
 			delegationID,
 			subnetAInfo,

--- a/tests/flows/validator-manager/erc20_token_staking.go
+++ b/tests/flows/validator-manager/erc20_token_staking.go
@@ -73,6 +73,7 @@ func ERC20TokenStakingManager(network interfaces.LocalNetwork) {
 	)
 	Expect(err).Should(BeNil())
 	validationID := utils.InitializeAndCompleteERC20ValidatorRegistration(
+		ctx,
 		network,
 		signatureAggregator,
 		fundedKey,
@@ -88,6 +89,7 @@ func ERC20TokenStakingManager(network interfaces.LocalNetwork) {
 	// Delist the validator
 	//
 	utils.InitializeAndCompleteEndERC20Validation(
+		ctx,
 		network,
 		signatureAggregator,
 		fundedKey,

--- a/tests/flows/validator-manager/native_delegation.go
+++ b/tests/flows/validator-manager/native_delegation.go
@@ -72,6 +72,7 @@ func NativeDelegation(network interfaces.LocalNetwork) {
 	Expect(err).Should(BeNil())
 	stakeAmount := new(big.Int).SetUint64(utils.DefaultMinStakeAmount)
 	validationID = utils.InitializeAndCompleteNativeValidatorRegistration(
+		ctx,
 		network,
 		signatureAggregator,
 		fundedKey,
@@ -97,6 +98,7 @@ func NativeDelegation(network interfaces.LocalNetwork) {
 		nonce := uint64(1)
 
 		receipt := utils.InitializeNativeDelegatorRegistration(
+			ctx,
 			fundedKey,
 			subnetAInfo,
 			validationID,
@@ -136,6 +138,7 @@ func NativeDelegation(network interfaces.LocalNetwork) {
 
 		// Deliver the Warp message to the subnet
 		receipt = utils.CompleteNativeDelegatorRegistration(
+			ctx,
 			fundedKey,
 			delegationID,
 			subnetAInfo,
@@ -157,6 +160,7 @@ func NativeDelegation(network interfaces.LocalNetwork) {
 	{
 		nonce := uint64(2)
 		receipt := utils.InitializeEndNativeDelegation(
+			ctx,
 			fundedKey,
 			subnetAInfo,
 			stakingManager,
@@ -191,6 +195,7 @@ func NativeDelegation(network interfaces.LocalNetwork) {
 
 		// Deliver the Warp message to the subnet
 		receipt = utils.CompleteEndNativeDelegation(
+			ctx,
 			fundedKey,
 			delegationID,
 			subnetAInfo,

--- a/tests/flows/validator-manager/native_token_staking.go
+++ b/tests/flows/validator-manager/native_token_staking.go
@@ -76,6 +76,7 @@ func NativeTokenStakingManager(network interfaces.LocalNetwork) {
 	Expect(err).Should(BeNil())
 	// Iniatiate validator registration
 	validationID := utils.InitializeAndCompleteNativeValidatorRegistration(
+		ctx,
 		network,
 		signatureAggregator,
 		fundedKey,
@@ -90,6 +91,7 @@ func NativeTokenStakingManager(network interfaces.LocalNetwork) {
 	// Delist the validator
 	//
 	utils.InitializeAndCompleteEndNativeValidation(
+		ctx,
 		network,
 		signatureAggregator,
 		fundedKey,

--- a/tests/flows/validator-manager/poa_to_pos.go
+++ b/tests/flows/validator-manager/poa_to_pos.go
@@ -112,6 +112,7 @@ func PoAMigrationToPoS(network interfaces.LocalNetwork) {
 	// Register a validator
 	poaWeight := uint64(1)
 	poaValidationID := utils.InitializeAndCompletePoAValidatorRegistration(
+		ctx,
 		network,
 		signatureAggregator,
 		ownerKey,
@@ -193,6 +194,7 @@ func PoAMigrationToPoS(network interfaces.LocalNetwork) {
 	Expect(err).Should(BeNil())
 
 	posValidationID := utils.InitializeAndCompleteNativeValidatorRegistration(
+		ctx,
 		network,
 		signatureAggregator,
 		fundedKey,
@@ -205,6 +207,7 @@ func PoAMigrationToPoS(network interfaces.LocalNetwork) {
 
 	// Delist the previous PoA validator
 	utils.InitializeAndCompleteEndNativeValidation(
+		ctx,
 		network,
 		signatureAggregator,
 		ownerKey,
@@ -219,6 +222,7 @@ func PoAMigrationToPoS(network interfaces.LocalNetwork) {
 
 	// Delist the PoS validator
 	utils.InitializeAndCompleteEndNativeValidation(
+		ctx,
 		network,
 		signatureAggregator,
 		fundedKey,

--- a/tests/flows/validator-manager/poa_validator_manager.go
+++ b/tests/flows/validator-manager/poa_validator_manager.go
@@ -107,6 +107,7 @@ func PoAValidatorManager(network interfaces.LocalNetwork) {
 
 		// Initiate validator registration
 		validationID = utils.InitializeAndCompletePoAValidatorRegistration(
+			ctx,
 			network,
 			signatureAggregator,
 			ownerKey,
@@ -133,6 +134,7 @@ func PoAValidatorManager(network interfaces.LocalNetwork) {
 		Expect(err).ShouldNot(BeNil())
 
 		utils.InitializeAndCompleteEndPoAValidation(
+			ctx,
 			network,
 			signatureAggregator,
 			ownerKey,

--- a/tests/utils/validator_manager.go
+++ b/tests/utils/validator_manager.go
@@ -103,7 +103,7 @@ func DeployAndInitializeNativeTokenStakingManager(
 		},
 	)
 	Expect(err).Should(BeNil())
-	WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 
 	return stakingManagerContractAddress, stakingManager
 }
@@ -172,7 +172,7 @@ func DeployAndInitializeERC20TokenStakingManager(
 		erc20Address,
 	)
 	Expect(err).Should(BeNil())
-	WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 
 	return stakingManagerContractAddress, stakingManager, erc20Address, erc20
 }
@@ -221,7 +221,7 @@ func DeployAndInitializePoAValidatorManager(
 		ownerAddress,
 	)
 	Expect(err).Should(BeNil())
-	WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 
 	return validatorManagerAddress, validatorManager
 }
@@ -288,6 +288,7 @@ func InitializeNativeTokenValidatorSet(
 	)
 	// Deliver the Warp message to the subnet
 	receipt := DeliverNativeTokenSubnetConversion(
+		ctx,
 		sendingKey,
 		subnetInfo,
 		validatorManagerAddress,
@@ -346,6 +347,7 @@ func InitializeERC20TokenValidatorSet(
 	)
 	// Deliver the Warp message to the subnet
 	receipt := DeliverERC20TokenSubnetConversion(
+		ctx,
 		sendingKey,
 		subnetInfo,
 		validatorManagerAddress,
@@ -405,6 +407,7 @@ func InitializePoAValidatorSet(
 	)
 	// Deliver the Warp message to the subnet
 	receipt := DeliverPoASubnetConversion(
+		ctx,
 		sendingKey,
 		subnetInfo,
 		validatorManagerAddress,
@@ -427,6 +430,7 @@ func InitializePoAValidatorSet(
 }
 
 func DeliverNativeTokenSubnetConversion(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
@@ -438,6 +442,7 @@ func DeliverNativeTokenSubnetConversion(
 	callData, err := abi.Pack("initializeValidatorSet", subnetConversionData, uint32(0))
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -447,6 +452,7 @@ func DeliverNativeTokenSubnetConversion(
 }
 
 func DeliverERC20TokenSubnetConversion(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
@@ -458,6 +464,7 @@ func DeliverERC20TokenSubnetConversion(
 	callData, err := abi.Pack("initializeValidatorSet", subnetConversionData, uint32(0))
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -467,6 +474,7 @@ func DeliverERC20TokenSubnetConversion(
 }
 
 func DeliverPoASubnetConversion(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
@@ -478,6 +486,7 @@ func DeliverPoASubnetConversion(
 	callData, err := abi.Pack("initializeValidatorSet", subnetConversionData, uint32(0))
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -491,6 +500,7 @@ func DeliverPoASubnetConversion(
 //
 
 func InitializeNativeValidatorRegistration(
+	ctx context.Context,
 	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakeAmount *big.Int,
@@ -513,7 +523,7 @@ func InitializeNativeValidatorRegistration(
 		DefaultMinStakeDurationSeconds,
 	)
 	Expect(err).Should(BeNil())
-	receipt := WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	receipt := WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 	registrationInitiatedEvent, err := GetEventFromLogs(
 		receipt.Logs,
 		stakingManager.ParseValidationPeriodCreated,
@@ -523,6 +533,7 @@ func InitializeNativeValidatorRegistration(
 }
 
 func InitializeERC20ValidatorRegistration(
+	ctx context.Context,
 	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakeAmount *big.Int,
@@ -533,7 +544,7 @@ func InitializeERC20ValidatorRegistration(
 	stakingManager *erc20tokenstakingmanager.ERC20TokenStakingManager,
 ) (*types.Receipt, ids.ID) {
 	ERC20Approve(
-		context.Background(),
+		ctx,
 		token,
 		stakingManagerAddress,
 		stakeAmount,
@@ -556,7 +567,7 @@ func InitializeERC20ValidatorRegistration(
 		stakeAmount,
 	)
 	Expect(err).Should(BeNil())
-	receipt := WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	receipt := WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 	registrationInitiatedEvent, err := GetEventFromLogs(
 		receipt.Logs,
 		stakingManager.ParseValidationPeriodCreated,
@@ -566,6 +577,7 @@ func InitializeERC20ValidatorRegistration(
 }
 
 func InitializePoAValidatorRegistration(
+	ctx context.Context,
 	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	weight uint64,
@@ -586,7 +598,7 @@ func InitializePoAValidatorRegistration(
 		weight,
 	)
 	Expect(err).Should(BeNil())
-	receipt := WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	receipt := WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 	registrationInitiatedEvent, err := GetEventFromLogs(
 		receipt.Logs,
 		validatorManager.ParseValidationPeriodCreated,
@@ -596,6 +608,7 @@ func InitializePoAValidatorRegistration(
 }
 
 func CompleteNativeValidatorRegistration(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
@@ -606,6 +619,7 @@ func CompleteNativeValidatorRegistration(
 	callData, err := abi.Pack("completeValidatorRegistration", uint32(0))
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -615,6 +629,7 @@ func CompleteNativeValidatorRegistration(
 }
 
 func CompleteERC20ValidatorRegistration(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
@@ -625,6 +640,7 @@ func CompleteERC20ValidatorRegistration(
 	callData, err := abi.Pack("completeValidatorRegistration", uint32(0))
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -634,6 +650,7 @@ func CompleteERC20ValidatorRegistration(
 }
 
 func CompletePoAValidatorRegistration(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
@@ -644,6 +661,7 @@ func CompletePoAValidatorRegistration(
 	callData, err := abi.Pack("completeValidatorRegistration", uint32(0))
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -654,13 +672,14 @@ func CompletePoAValidatorRegistration(
 
 // Calls a method that retreived a signed Warp message from the transaction's access list
 func CallWarpReceiver(
+	ctx context.Context,
 	callData []byte,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	contract common.Address,
 	signedMessage *avalancheWarp.Message,
 ) *types.Receipt {
-	gasFeeCap, gasTipCap, nonce := CalculateTxParams(context.Background(), subnet, PrivateKeyToAddress(sendingKey))
+	gasFeeCap, gasTipCap, nonce := CalculateTxParams(ctx, subnet, PrivateKeyToAddress(sendingKey))
 	registrationTx := predicateutils.NewPredicateTx(
 		subnet.EVMChainID,
 		nonce,
@@ -675,10 +694,11 @@ func CallWarpReceiver(
 		signedMessage.Bytes(),
 	)
 	signedRegistrationTx := SignTransaction(registrationTx, sendingKey, subnet.EVMChainID)
-	return SendTransactionAndWaitForSuccess(context.Background(), subnet, signedRegistrationTx)
+	return SendTransactionAndWaitForSuccess(ctx, subnet, signedRegistrationTx)
 }
 
 func InitializeAndCompleteNativeValidatorRegistration(
+	ctx context.Context,
 	network interfaces.LocalNetwork,
 	signatureAggregator *aggregator.SignatureAggregator,
 	fundedKey *ecdsa.PrivateKey,
@@ -692,6 +712,7 @@ func InitializeAndCompleteNativeValidatorRegistration(
 	nodeID := ids.GenerateTestID()
 	blsPublicKey := [bls.PublicKeyLen]byte{}
 	receipt, validationID := InitializeNativeValidatorRegistration(
+		ctx,
 		fundedKey,
 		subnetInfo,
 		stakeAmount,
@@ -702,7 +723,7 @@ func InitializeAndCompleteNativeValidatorRegistration(
 
 	// Gather subnet-evm Warp signatures for the RegisterSubnetValidatorMessage & relay to the P-Chain
 	// (Sending to the P-Chain will be skipped for now)
-	signedWarpMessage := network.ConstructSignedWarpMessage(context.Background(), receipt, subnetInfo, pChainInfo)
+	signedWarpMessage := network.ConstructSignedWarpMessage(ctx, receipt, subnetInfo, pChainInfo)
 
 	weight, err := stakingManager.ValueToWeight(
 		&bind.CallOpts{},
@@ -730,6 +751,7 @@ func InitializeAndCompleteNativeValidatorRegistration(
 
 	// Deliver the Warp message to the subnet
 	receipt = CompleteNativeValidatorRegistration(
+		ctx,
 		fundedKey,
 		subnetInfo,
 		stakingManagerContractAddress,
@@ -747,6 +769,7 @@ func InitializeAndCompleteNativeValidatorRegistration(
 }
 
 func InitializeAndCompleteERC20ValidatorRegistration(
+	ctx context.Context,
 	network interfaces.LocalNetwork,
 	signatureAggregator *aggregator.SignatureAggregator,
 	fundedKey *ecdsa.PrivateKey,
@@ -762,6 +785,7 @@ func InitializeAndCompleteERC20ValidatorRegistration(
 	blsPublicKey := [bls.PublicKeyLen]byte{}
 	var receipt *types.Receipt
 	receipt, validationID := InitializeERC20ValidatorRegistration(
+		ctx,
 		fundedKey,
 		subnetInfo,
 		stakeAmount,
@@ -774,7 +798,7 @@ func InitializeAndCompleteERC20ValidatorRegistration(
 
 	// Gather subnet-evm Warp signatures for the RegisterSubnetValidatorMessage & relay to the P-Chain
 	// (Sending to the P-Chain will be skipped for now)
-	signedWarpMessage := network.ConstructSignedWarpMessage(context.Background(), receipt, subnetInfo, pChainInfo)
+	signedWarpMessage := network.ConstructSignedWarpMessage(ctx, receipt, subnetInfo, pChainInfo)
 
 	weight, err := stakingManager.ValueToWeight(
 		&bind.CallOpts{},
@@ -802,6 +826,7 @@ func InitializeAndCompleteERC20ValidatorRegistration(
 
 	// Deliver the Warp message to the subnet
 	receipt = CompleteERC20ValidatorRegistration(
+		ctx,
 		fundedKey,
 		subnetInfo,
 		stakingManagerAddress,
@@ -819,6 +844,7 @@ func InitializeAndCompleteERC20ValidatorRegistration(
 }
 
 func InitializeAndCompletePoAValidatorRegistration(
+	ctx context.Context,
 	network interfaces.LocalNetwork,
 	signatureAggregator *aggregator.SignatureAggregator,
 	ownerKey *ecdsa.PrivateKey,
@@ -833,6 +859,7 @@ func InitializeAndCompletePoAValidatorRegistration(
 	nodeID := ids.GenerateTestID()
 	blsPublicKey := [bls.PublicKeyLen]byte{}
 	receipt, validationID := InitializePoAValidatorRegistration(
+		ctx,
 		ownerKey,
 		subnetInfo,
 		weight,
@@ -843,7 +870,7 @@ func InitializeAndCompletePoAValidatorRegistration(
 
 	// Gather subnet-evm Warp signatures for the RegisterSubnetValidatorMessage & relay to the P-Chain
 	// (Sending to the P-Chain will be skipped for now)
-	signedWarpMessage := network.ConstructSignedWarpMessage(context.Background(), receipt, subnetInfo, pChainInfo)
+	signedWarpMessage := network.ConstructSignedWarpMessage(ctx, receipt, subnetInfo, pChainInfo)
 
 	// Validate the Warp message, (this will be done on the P-Chain in the future)
 	ValidateRegisterSubnetValidatorMessage(
@@ -866,6 +893,7 @@ func InitializeAndCompletePoAValidatorRegistration(
 
 	// Deliver the Warp message to the subnet
 	receipt = CompletePoAValidatorRegistration(
+		ctx,
 		fundedKey,
 		subnetInfo,
 		validatorManagerAddress,
@@ -883,6 +911,7 @@ func InitializeAndCompletePoAValidatorRegistration(
 }
 
 func InitializeEndNativeValidation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManager *nativetokenstakingmanager.NativeTokenStakingManager,
@@ -897,10 +926,11 @@ func InitializeEndNativeValidation(
 		0,
 	)
 	Expect(err).Should(BeNil())
-	return WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	return WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 }
 
 func InitializeEndERC20Validation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManager *erc20tokenstakingmanager.ERC20TokenStakingManager,
@@ -915,10 +945,11 @@ func InitializeEndERC20Validation(
 		0,
 	)
 	Expect(err).Should(BeNil())
-	return WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	return WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 }
 
 func InitializeEndPoAValidation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManager *poavalidatormanager.PoAValidatorManager,
@@ -931,10 +962,11 @@ func InitializeEndPoAValidation(
 		validationID,
 	)
 	Expect(err).Should(BeNil())
-	return WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	return WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 }
 
 func CompleteEndNativeValidation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
@@ -945,6 +977,7 @@ func CompleteEndNativeValidation(
 	callData, err := abi.Pack("completeEndValidation", uint32(0))
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -954,6 +987,7 @@ func CompleteEndNativeValidation(
 }
 
 func CompleteEndERC20Validation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
@@ -964,6 +998,7 @@ func CompleteEndERC20Validation(
 	callData, err := abi.Pack("completeEndValidation", uint32(0))
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -973,6 +1008,7 @@ func CompleteEndERC20Validation(
 }
 
 func CompleteEndPoAValidation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
@@ -983,6 +1019,7 @@ func CompleteEndPoAValidation(
 	callData, err := abi.Pack("completeEndValidation", uint32(0))
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -992,6 +1029,7 @@ func CompleteEndPoAValidation(
 }
 
 func InitializeERC20DelegatorRegistration(
+	ctx context.Context,
 	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validationID ids.ID,
@@ -1001,7 +1039,7 @@ func InitializeERC20DelegatorRegistration(
 	stakingManager *erc20tokenstakingmanager.ERC20TokenStakingManager,
 ) *types.Receipt {
 	ERC20Approve(
-		context.Background(),
+		ctx,
 		token,
 		stakingManagerAddress,
 		delegationAmount,
@@ -1018,7 +1056,7 @@ func InitializeERC20DelegatorRegistration(
 		delegationAmount,
 	)
 	Expect(err).Should(BeNil())
-	receipt := WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	receipt := WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 	_, err = GetEventFromLogs(
 		receipt.Logs,
 		stakingManager.ParseDelegatorAdded,
@@ -1028,6 +1066,7 @@ func InitializeERC20DelegatorRegistration(
 }
 
 func CompleteERC20DelegatorRegistration(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	delegationID ids.ID,
 	subnet interfaces.SubnetTestInfo,
@@ -1039,6 +1078,7 @@ func CompleteERC20DelegatorRegistration(
 	callData, err := abi.Pack("completeDelegatorRegistration", uint32(0), delegationID)
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -1048,6 +1088,7 @@ func CompleteERC20DelegatorRegistration(
 }
 
 func InitializeEndERC20Delegation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManager *erc20tokenstakingmanager.ERC20TokenStakingManager,
@@ -1062,10 +1103,11 @@ func InitializeEndERC20Delegation(
 		0,
 	)
 	Expect(err).Should(BeNil())
-	return WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	return WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 }
 
 func CompleteEndERC20Delegation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	delegationID ids.ID,
 	subnet interfaces.SubnetTestInfo,
@@ -1077,6 +1119,7 @@ func CompleteEndERC20Delegation(
 	callData, err := abi.Pack("completeEndDelegation", uint32(0), delegationID)
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -1085,7 +1128,9 @@ func CompleteEndERC20Delegation(
 	)
 }
 
-func InitializeNativeDelegatorRegistration(senderKey *ecdsa.PrivateKey,
+func InitializeNativeDelegatorRegistration(
+	ctx context.Context,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validationID ids.ID,
 	delegationAmount *big.Int,
@@ -1101,7 +1146,7 @@ func InitializeNativeDelegatorRegistration(senderKey *ecdsa.PrivateKey,
 		validationID,
 	)
 	Expect(err).Should(BeNil())
-	receipt := WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	receipt := WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 	_, err = GetEventFromLogs(
 		receipt.Logs,
 		stakingManager.ParseDelegatorAdded,
@@ -1111,6 +1156,7 @@ func InitializeNativeDelegatorRegistration(senderKey *ecdsa.PrivateKey,
 }
 
 func CompleteNativeDelegatorRegistration(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	delegationID ids.ID,
 	subnet interfaces.SubnetTestInfo,
@@ -1122,6 +1168,7 @@ func CompleteNativeDelegatorRegistration(
 	callData, err := abi.Pack("completeDelegatorRegistration", uint32(0), delegationID)
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -1131,6 +1178,7 @@ func CompleteNativeDelegatorRegistration(
 }
 
 func InitializeEndNativeDelegation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManager *nativetokenstakingmanager.NativeTokenStakingManager,
@@ -1145,10 +1193,11 @@ func InitializeEndNativeDelegation(
 		0,
 	)
 	Expect(err).Should(BeNil())
-	return WaitForTransactionSuccess(context.Background(), subnet, tx.Hash())
+	return WaitForTransactionSuccess(ctx, subnet, tx.Hash())
 }
 
 func CompleteEndNativeDelegation(
+	ctx context.Context,
 	sendingKey *ecdsa.PrivateKey,
 	delegationID ids.ID,
 	subnet interfaces.SubnetTestInfo,
@@ -1160,6 +1209,7 @@ func CompleteEndNativeDelegation(
 	callData, err := abi.Pack("completeEndDelegation", uint32(0), delegationID)
 	Expect(err).Should(BeNil())
 	return CallWarpReceiver(
+		ctx,
 		callData,
 		sendingKey,
 		subnet,
@@ -1169,6 +1219,7 @@ func CompleteEndNativeDelegation(
 }
 
 func InitializeAndCompleteEndNativeValidation(
+	ctx context.Context,
 	network interfaces.LocalNetwork,
 	signatureAggregator *aggregator.SignatureAggregator,
 	fundedKey *ecdsa.PrivateKey,
@@ -1180,8 +1231,9 @@ func InitializeAndCompleteEndNativeValidation(
 	weight uint64,
 	nonce uint64,
 ) {
-	WaitMinStakeDuration(subnetInfo, fundedKey)
+	WaitMinStakeDuration(ctx, subnetInfo, fundedKey)
 	receipt := InitializeEndNativeValidation(
+		ctx,
 		fundedKey,
 		subnetInfo,
 		stakingManager,
@@ -1197,7 +1249,7 @@ func InitializeAndCompleteEndNativeValidation(
 
 	// Gather subnet-evm Warp signatures for the SetSubnetValidatorWeightMessage & relay to the P-Chain
 	// (Sending to the P-Chain will be skipped for now)
-	signedWarpMessage := network.ConstructSignedWarpMessage(context.Background(), receipt, subnetInfo, pChainInfo)
+	signedWarpMessage := network.ConstructSignedWarpMessage(ctx, receipt, subnetInfo, pChainInfo)
 	Expect(err).Should(BeNil())
 
 	// Validate the Warp message, (this will be done on the P-Chain in the future)
@@ -1215,6 +1267,7 @@ func InitializeAndCompleteEndNativeValidation(
 
 	// Deliver the Warp message to the subnet
 	receipt = CompleteEndNativeValidation(
+		ctx,
 		fundedKey,
 		subnetInfo,
 		stakingManagerAddress,
@@ -1231,6 +1284,7 @@ func InitializeAndCompleteEndNativeValidation(
 }
 
 func InitializeAndCompleteEndERC20Validation(
+	ctx context.Context,
 	network interfaces.LocalNetwork,
 	signatureAggregator *aggregator.SignatureAggregator,
 	fundedKey *ecdsa.PrivateKey,
@@ -1242,8 +1296,9 @@ func InitializeAndCompleteEndERC20Validation(
 	weight uint64,
 	nonce uint64,
 ) {
-	WaitMinStakeDuration(subnetInfo, fundedKey)
+	WaitMinStakeDuration(ctx, subnetInfo, fundedKey)
 	receipt := InitializeEndERC20Validation(
+		ctx,
 		fundedKey,
 		subnetInfo,
 		stakingManager,
@@ -1259,7 +1314,7 @@ func InitializeAndCompleteEndERC20Validation(
 
 	// Gather subnet-evm Warp signatures for the SetSubnetValidatorWeightMessage & relay to the P-Chain
 	// (Sending to the P-Chain will be skipped for now)
-	signedWarpMessage := network.ConstructSignedWarpMessage(context.Background(), receipt, subnetInfo, pChainInfo)
+	signedWarpMessage := network.ConstructSignedWarpMessage(ctx, receipt, subnetInfo, pChainInfo)
 	Expect(err).Should(BeNil())
 
 	// Validate the Warp message, (this will be done on the P-Chain in the future)
@@ -1277,6 +1332,7 @@ func InitializeAndCompleteEndERC20Validation(
 
 	// Deliver the Warp message to the subnet
 	receipt = CompleteEndERC20Validation(
+		ctx,
 		fundedKey,
 		subnetInfo,
 		stakingManagerAddress,
@@ -1293,6 +1349,7 @@ func InitializeAndCompleteEndERC20Validation(
 }
 
 func InitializeAndCompleteEndPoAValidation(
+	ctx context.Context,
 	network interfaces.LocalNetwork,
 	signatureAggregator *aggregator.SignatureAggregator,
 	ownerKey *ecdsa.PrivateKey,
@@ -1306,6 +1363,7 @@ func InitializeAndCompleteEndPoAValidation(
 	nonce uint64,
 ) {
 	receipt := InitializeEndPoAValidation(
+		ctx,
 		ownerKey,
 		subnetInfo,
 		validatorManager,
@@ -1321,7 +1379,7 @@ func InitializeAndCompleteEndPoAValidation(
 
 	// Gather subnet-evm Warp signatures for the SetSubnetValidatorWeightMessage & relay to the P-Chain
 	// (Sending to the P-Chain will be skipped for now)
-	signedWarpMessage := network.ConstructSignedWarpMessage(context.Background(), receipt, subnetInfo, pChainInfo)
+	signedWarpMessage := network.ConstructSignedWarpMessage(ctx, receipt, subnetInfo, pChainInfo)
 	Expect(err).Should(BeNil())
 
 	// Validate the Warp message, (this will be done on the P-Chain in the future)
@@ -1339,6 +1397,7 @@ func InitializeAndCompleteEndPoAValidation(
 
 	// Deliver the Warp message to the subnet
 	receipt = CompleteEndPoAValidation(
+		ctx,
 		ownerKey,
 		subnetInfo,
 		validatorManagerAddress,
@@ -1499,6 +1558,7 @@ func ValidateSetSubnetValidatorWeightMessage(
 }
 
 func WaitMinStakeDuration(
+	ctx context.Context,
 	subnet interfaces.SubnetTestInfo,
 	fundedKey *ecdsa.PrivateKey,
 ) {
@@ -1508,7 +1568,7 @@ func WaitMinStakeDuration(
 	// Send a loopback transaction to self to force a block production
 	// before delisting the validator.
 	SendNativeTransfer(
-		context.Background(),
+		ctx,
 		subnet,
 		fundedKey,
 		common.Address{},

--- a/tests/utils/validator_manager.go
+++ b/tests/utils/validator_manager.go
@@ -253,7 +253,7 @@ func DeployExampleRewardCalculator(
 
 func InitializeNativeTokenValidatorSet(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnetInfo interfaces.SubnetTestInfo,
 	pChainInfo interfaces.SubnetTestInfo,
 	validatorManager *nativetokenstakingmanager.NativeTokenStakingManager,
@@ -289,7 +289,7 @@ func InitializeNativeTokenValidatorSet(
 	// Deliver the Warp message to the subnet
 	receipt := DeliverNativeTokenSubnetConversion(
 		ctx,
-		sendingKey,
+		senderKey,
 		subnetInfo,
 		validatorManagerAddress,
 		subnetConversionSignedMessage,
@@ -312,7 +312,7 @@ func InitializeNativeTokenValidatorSet(
 
 func InitializeERC20TokenValidatorSet(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnetInfo interfaces.SubnetTestInfo,
 	pChainInfo interfaces.SubnetTestInfo,
 	validatorManager *erc20tokenstakingmanager.ERC20TokenStakingManager,
@@ -348,7 +348,7 @@ func InitializeERC20TokenValidatorSet(
 	// Deliver the Warp message to the subnet
 	receipt := DeliverERC20TokenSubnetConversion(
 		ctx,
-		sendingKey,
+		senderKey,
 		subnetInfo,
 		validatorManagerAddress,
 		subnetConversionSignedMessage,
@@ -371,7 +371,7 @@ func InitializeERC20TokenValidatorSet(
 
 func InitializePoAValidatorSet(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnetInfo interfaces.SubnetTestInfo,
 	pChainInfo interfaces.SubnetTestInfo,
 	validatorManager *poavalidatormanager.PoAValidatorManager,
@@ -408,7 +408,7 @@ func InitializePoAValidatorSet(
 	// Deliver the Warp message to the subnet
 	receipt := DeliverPoASubnetConversion(
 		ctx,
-		sendingKey,
+		senderKey,
 		subnetInfo,
 		validatorManagerAddress,
 		subnetConversionSignedMessage,
@@ -431,7 +431,7 @@ func InitializePoAValidatorSet(
 
 func DeliverNativeTokenSubnetConversion(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
 	subnetConversionSignedMessage *avalancheWarp.Message,
@@ -444,7 +444,7 @@ func DeliverNativeTokenSubnetConversion(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		validatorManagerAddress,
 		subnetConversionSignedMessage,
@@ -453,7 +453,7 @@ func DeliverNativeTokenSubnetConversion(
 
 func DeliverERC20TokenSubnetConversion(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
 	subnetConversionSignedMessage *avalancheWarp.Message,
@@ -466,7 +466,7 @@ func DeliverERC20TokenSubnetConversion(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		validatorManagerAddress,
 		subnetConversionSignedMessage,
@@ -475,7 +475,7 @@ func DeliverERC20TokenSubnetConversion(
 
 func DeliverPoASubnetConversion(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
 	subnetConversionSignedMessage *avalancheWarp.Message,
@@ -488,7 +488,7 @@ func DeliverPoASubnetConversion(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		validatorManagerAddress,
 		subnetConversionSignedMessage,
@@ -609,7 +609,7 @@ func InitializePoAValidatorRegistration(
 
 func CompleteNativeValidatorRegistration(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
 	registrationSignedMessage *avalancheWarp.Message,
@@ -621,7 +621,7 @@ func CompleteNativeValidatorRegistration(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		stakingManagerContractAddress,
 		registrationSignedMessage,
@@ -630,7 +630,7 @@ func CompleteNativeValidatorRegistration(
 
 func CompleteERC20ValidatorRegistration(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
 	registrationSignedMessage *avalancheWarp.Message,
@@ -642,7 +642,7 @@ func CompleteERC20ValidatorRegistration(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		stakingManagerContractAddress,
 		registrationSignedMessage,
@@ -651,7 +651,7 @@ func CompleteERC20ValidatorRegistration(
 
 func CompletePoAValidatorRegistration(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
 	registrationSignedMessage *avalancheWarp.Message,
@@ -663,7 +663,7 @@ func CompletePoAValidatorRegistration(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		validatorManagerAddress,
 		registrationSignedMessage,
@@ -674,12 +674,12 @@ func CompletePoAValidatorRegistration(
 func CallWarpReceiver(
 	ctx context.Context,
 	callData []byte,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	contract common.Address,
 	signedMessage *avalancheWarp.Message,
 ) *types.Receipt {
-	gasFeeCap, gasTipCap, nonce := CalculateTxParams(ctx, subnet, PrivateKeyToAddress(sendingKey))
+	gasFeeCap, gasTipCap, nonce := CalculateTxParams(ctx, subnet, PrivateKeyToAddress(senderKey))
 	registrationTx := predicateutils.NewPredicateTx(
 		subnet.EVMChainID,
 		nonce,
@@ -693,7 +693,7 @@ func CallWarpReceiver(
 		warp.ContractAddress,
 		signedMessage.Bytes(),
 	)
-	signedRegistrationTx := SignTransaction(registrationTx, sendingKey, subnet.EVMChainID)
+	signedRegistrationTx := SignTransaction(registrationTx, senderKey, subnet.EVMChainID)
 	return SendTransactionAndWaitForSuccess(ctx, subnet, signedRegistrationTx)
 }
 
@@ -912,12 +912,12 @@ func InitializeAndCompletePoAValidatorRegistration(
 
 func InitializeEndNativeValidation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManager *nativetokenstakingmanager.NativeTokenStakingManager,
 	validationID ids.ID,
 ) *types.Receipt {
-	opts, err := bind.NewKeyedTransactorWithChainID(sendingKey, subnet.EVMChainID)
+	opts, err := bind.NewKeyedTransactorWithChainID(senderKey, subnet.EVMChainID)
 	Expect(err).Should(BeNil())
 	tx, err := stakingManager.InitializeEndValidation(
 		opts,
@@ -931,12 +931,12 @@ func InitializeEndNativeValidation(
 
 func InitializeEndERC20Validation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManager *erc20tokenstakingmanager.ERC20TokenStakingManager,
 	validationID ids.ID,
 ) *types.Receipt {
-	opts, err := bind.NewKeyedTransactorWithChainID(sendingKey, subnet.EVMChainID)
+	opts, err := bind.NewKeyedTransactorWithChainID(senderKey, subnet.EVMChainID)
 	Expect(err).Should(BeNil())
 	tx, err := stakingManager.InitializeEndValidation(
 		opts,
@@ -950,12 +950,12 @@ func InitializeEndERC20Validation(
 
 func InitializeEndPoAValidation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManager *poavalidatormanager.PoAValidatorManager,
 	validationID ids.ID,
 ) *types.Receipt {
-	opts, err := bind.NewKeyedTransactorWithChainID(sendingKey, subnet.EVMChainID)
+	opts, err := bind.NewKeyedTransactorWithChainID(senderKey, subnet.EVMChainID)
 	Expect(err).Should(BeNil())
 	tx, err := validatorManager.InitializeEndValidation(
 		opts,
@@ -967,7 +967,7 @@ func InitializeEndPoAValidation(
 
 func CompleteEndNativeValidation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
 	registrationSignedMessage *avalancheWarp.Message,
@@ -979,7 +979,7 @@ func CompleteEndNativeValidation(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		stakingManagerContractAddress,
 		registrationSignedMessage,
@@ -988,7 +988,7 @@ func CompleteEndNativeValidation(
 
 func CompleteEndERC20Validation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
 	registrationSignedMessage *avalancheWarp.Message,
@@ -1000,7 +1000,7 @@ func CompleteEndERC20Validation(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		stakingManagerContractAddress,
 		registrationSignedMessage,
@@ -1009,7 +1009,7 @@ func CompleteEndERC20Validation(
 
 func CompleteEndPoAValidation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	validatorManagerAddress common.Address,
 	registrationSignedMessage *avalancheWarp.Message,
@@ -1021,7 +1021,7 @@ func CompleteEndPoAValidation(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		validatorManagerAddress,
 		registrationSignedMessage,
@@ -1067,7 +1067,7 @@ func InitializeERC20DelegatorRegistration(
 
 func CompleteERC20DelegatorRegistration(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	delegationID ids.ID,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
@@ -1080,7 +1080,7 @@ func CompleteERC20DelegatorRegistration(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		stakingManagerContractAddress,
 		signedMessage,
@@ -1089,12 +1089,12 @@ func CompleteERC20DelegatorRegistration(
 
 func InitializeEndERC20Delegation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManager *erc20tokenstakingmanager.ERC20TokenStakingManager,
 	delegationID ids.ID,
 ) *types.Receipt {
-	opts, err := bind.NewKeyedTransactorWithChainID(sendingKey, subnet.EVMChainID)
+	opts, err := bind.NewKeyedTransactorWithChainID(senderKey, subnet.EVMChainID)
 	Expect(err).Should(BeNil())
 	tx, err := stakingManager.InitializeEndDelegation(
 		opts,
@@ -1108,7 +1108,7 @@ func InitializeEndERC20Delegation(
 
 func CompleteEndERC20Delegation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	delegationID ids.ID,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
@@ -1121,7 +1121,7 @@ func CompleteEndERC20Delegation(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		stakingManagerContractAddress,
 		signedMessage,
@@ -1157,7 +1157,7 @@ func InitializeNativeDelegatorRegistration(
 
 func CompleteNativeDelegatorRegistration(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	delegationID ids.ID,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
@@ -1170,7 +1170,7 @@ func CompleteNativeDelegatorRegistration(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		stakingManagerContractAddress,
 		signedMessage,
@@ -1179,12 +1179,12 @@ func CompleteNativeDelegatorRegistration(
 
 func InitializeEndNativeDelegation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	subnet interfaces.SubnetTestInfo,
 	stakingManager *nativetokenstakingmanager.NativeTokenStakingManager,
 	delegationID ids.ID,
 ) *types.Receipt {
-	opts, err := bind.NewKeyedTransactorWithChainID(sendingKey, subnet.EVMChainID)
+	opts, err := bind.NewKeyedTransactorWithChainID(senderKey, subnet.EVMChainID)
 	Expect(err).Should(BeNil())
 	tx, err := stakingManager.InitializeEndDelegation(
 		opts,
@@ -1198,7 +1198,7 @@ func InitializeEndNativeDelegation(
 
 func CompleteEndNativeDelegation(
 	ctx context.Context,
-	sendingKey *ecdsa.PrivateKey,
+	senderKey *ecdsa.PrivateKey,
 	delegationID ids.ID,
 	subnet interfaces.SubnetTestInfo,
 	stakingManagerContractAddress common.Address,
@@ -1211,7 +1211,7 @@ func CompleteEndNativeDelegation(
 	return CallWarpReceiver(
 		ctx,
 		callData,
-		sendingKey,
+		senderKey,
 		subnet,
 		stakingManagerContractAddress,
 		signedMessage,


### PR DESCRIPTION
## Why this should be merged
Adds context to all the validator manager function calls to be passed through.

Renames all instances of `sendingKey` to `senderKey` which we had been using previously.