### PR TITLE
Update ValidatorMessages.sol

### DIFF
--- a/contracts/validator-manager/ValidatorMessages.sol
+++ b/contracts/validator-manager/ValidatorMessages.sol
@@ -166,7 +166,7 @@ library ValidatorMessages {
         // The approach below of encoding initialValidators using `abi.encodePacked` in a loop
         // was tested against pre-allocating the array and doing manual byte by byte packing and
         // it was found to be more gas efficient.
-        for (uint256 i; i < subnetConversionData.initialValidators.length; i++) {
+        for (uint256 i; i < subnetConversionData.initialValidators.length; ++i) {
             res = abi.encodePacked(
                 res,
                 uint32(subnetConversionData.initialValidators[i].nodeID.length),
@@ -238,7 +238,7 @@ library ValidatorMessages {
             validationPeriod.remainingBalanceOwner.threshold,
             uint32(validationPeriod.remainingBalanceOwner.addresses.length)
         );
-        for (uint256 i; i < validationPeriod.remainingBalanceOwner.addresses.length; i++) {
+        for (uint256 i; i < validationPeriod.remainingBalanceOwner.addresses.length; ++i) {
             res = abi.encodePacked(res, validationPeriod.remainingBalanceOwner.addresses[i]);
         }
         res = abi.encodePacked(
@@ -246,7 +246,7 @@ library ValidatorMessages {
             validationPeriod.disableOwner.threshold,
             uint32(validationPeriod.disableOwner.addresses.length)
         );
-        for (uint256 i; i < validationPeriod.disableOwner.addresses.length; i++) {
+        for (uint256 i; i < validationPeriod.disableOwner.addresses.length; ++i) {
             res = abi.encodePacked(res, validationPeriod.disableOwner.addresses[i]);
         }
         res = abi.encodePacked(res, validationPeriod.weight);


### PR DESCRIPTION
## Why this should be merged
Pre-increment uses slightly less gas. It is now used consistently in `ValidatorMessages.sol`

## How this works
Explanation here: https://detectors.auditbase.com/for-loop-gas-optimization

## How this was tested
N/A

## How is this documented
N/A