### PR TITLE
Mock the reward functionality of the native-manager

### DIFF
--- a/contracts/validator-manager/tests/NativeTokenStakingManagerTests.t.sol
+++ b/contracts/validator-manager/tests/NativeTokenStakingManagerTests.t.sol
@@ -5,6 +5,7 @@
 
 pragma solidity 0.8.25;
 
+import {Test} from "@forge-std/Test.sol";
 import {PoSValidatorManagerTest} from "./PoSValidatorManagerTests.t.sol";
 import {NativeTokenStakingManager} from "../NativeTokenStakingManager.sol";
 import {PoSValidatorManager} from "../PoSValidatorManager.sol";
@@ -249,25 +250,15 @@ contract NativeTokenStakingManagerTest is PoSValidatorManagerTest {
     }
 
     function _expectRewardIssuance(address account, uint256 amount) internal override {
-        vm.mockCall(
-            address(app.NATIVE_MINTER()),
-            abi.encodeCall(INativeMinter.mintNativeCoin, (account, amount)),
-            ""
-        );
-        // empty calldata implies the receive function will be called:
-        vm.mockCall({
-            callee: account,
-            msgValue: amount,
-            data: "", // implies receive()
-            returnData: ""
-        });
-        // Units tests don't have access to the native minter precompile, so use vm.deal instead.
-        vm.deal(account, account.balance + amount);
+        address nativeMinter = address(app.NATIVE_MINTER());
+        bytes memory callData = abi.encodeCall(INativeMinter.mintNativeCoin, (account, amount));
+        vm.mockCall(nativeMinter, callData, "");
+        vm.expectCall(nativeMinter, callData);
     }
 
     function _setUp() internal override returns (IValidatorManager) {
         // Construct the object under test
-        app = new NativeTokenStakingManager(ICMInitializable.Allowed);
+        app = new TestableNativeTokenStakingManager(ICMInitializable.Allowed);
         rewardCalculator = new ExampleRewardCalculator(DEFAULT_REWARD_RATE);
         app.initialize(
             PoSValidatorManagerSettings({
@@ -292,5 +283,15 @@ contract NativeTokenStakingManagerTest is PoSValidatorManagerTest {
 
     function _getStakeAssetBalance(address account) internal view override returns (uint256) {
         return account.balance;
+    }
+}
+
+contract TestableNativeTokenStakingManager is NativeTokenStakingManager, Test {
+    constructor(ICMInitializable init) NativeTokenStakingManager(init) {}
+
+    function _reward(address account, uint256 amount) internal virtual override {
+        super._reward(account, amount);
+        // Units tests don't have access to the native minter precompile, so use vm.deal instead.
+        vm.deal(account, account.balance + amount);
     }
 }


### PR DESCRIPTION
## Why this should be merged

We were actually triggering logic in a function named `_expect*`. It was super misleading and really hard to track down why that was happening. Instead, I've properly mocked the functionality, triggering the `vm.deal` logic when the `_reward` function is called instead of afterwards. 

## How this works

I've effectively monkey-patched the `_rewardFunction`.

## How this was tested

It is a test :wink:

## How is this docuomented

There's a code comment that was already there that I moved.
