### PR TITLE
Cleanup: Rename bash variable

### DIFF
--- a/scripts/deploy_registry.sh
+++ b/scripts/deploy_registry.sh
@@ -4,14 +4,14 @@
 
 set -e
 
-TELEPORTER_PATH=$(
+ICM_CONTRACTS_PATH=$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     cd .. && pwd
 )
 
 # Check that foundry (specifically cast) is installed.
 if ! command -v cast &> /dev/null; then
-    echo "cast not found. You can install by calling $TELEPORTER_PATH/scripts/install_foundry.sh" && exit 1
+    echo "cast not found. You can install by calling $ICM_CONTRACTS_PATH/scripts/install_foundry.sh" && exit 1
 fi
 
 # Check that jq is installed.

--- a/scripts/deploy_teleporter.sh
+++ b/scripts/deploy_teleporter.sh
@@ -4,14 +4,14 @@
 
 set -e
 
-TELEPORTER_PATH=$(
+ICM_CONTRACTS_PATH=$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     cd .. && pwd
 )
 
 # Check that foundry (specifically cast) is installed.
 if ! command -v cast &> /dev/null; then
-    echo "cast not found. You can install by calling $TELEPORTER_PATH/scripts/install_foundry.sh" && exit 1
+    echo "cast not found. You can install by calling $ICM_CONTRACTS_PATH/scripts/install_foundry.sh" && exit 1
 fi
 
 # Check that jq is installed.

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-TELEPORTER_PATH=$(
+ICM_CONTRACTS_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")"
   cd ../ && pwd
 )
@@ -26,7 +26,7 @@ Options:
 EOF
 }
 
-valid_components=$(ls -d $TELEPORTER_PATH/tests/suites/*/ | xargs -n 1 basename)
+valid_components=$(ls -d $ICM_CONTRACTS_PATH/tests/suites/*/ | xargs -n 1 basename)
 components=
 
 while [ $# -gt 0 ]; do
@@ -58,23 +58,23 @@ for component in $(echo $components | tr ',' ' '); do
     fi
 done
 
-source "$TELEPORTER_PATH"/scripts/constants.sh
-source "$TELEPORTER_PATH"/scripts/versions.sh
+source "$ICM_CONTRACTS_PATH"/scripts/constants.sh
+source "$ICM_CONTRACTS_PATH"/scripts/versions.sh
 
 BASEDIR=${BASEDIR:-"$HOME/.teleporter-deps"}
 
 cwd=$(pwd)
 # Install the avalanchego and subnet-evm binaries
 rm -rf $BASEDIR/avalanchego
-BASEDIR=$BASEDIR AVALANCHEGO_BUILD_PATH=$BASEDIR/avalanchego "${TELEPORTER_PATH}/scripts/install_avalanchego_release.sh"
-BASEDIR=$BASEDIR "${TELEPORTER_PATH}/scripts/install_subnetevm_release.sh"
+BASEDIR=$BASEDIR AVALANCHEGO_BUILD_PATH=$BASEDIR/avalanchego "${ICM_CONTRACTS_PATH}/scripts/install_avalanchego_release.sh"
+BASEDIR=$BASEDIR "${ICM_CONTRACTS_PATH}/scripts/install_subnetevm_release.sh"
 
 cp ${BASEDIR}/subnet-evm/subnet-evm ${BASEDIR}/avalanchego/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
 echo "Copied ${BASEDIR}/subnet-evm/subnet-evm binary to ${BASEDIR}/avalanchego/plugins/"
 
 export AVALANCHEGO_BUILD_PATH=$BASEDIR/avalanchego
 
-cd $TELEPORTER_PATH
+cd $ICM_CONTRACTS_PATH
 if command -v forge &> /dev/null; then
   forge build --skip test
 else
@@ -82,7 +82,7 @@ else
   $HOME/.foundry/bin/forge build
 fi
 
-cd "$TELEPORTER_PATH"
+cd "$ICM_CONTRACTS_PATH"
 # Build ginkgo
 # to install the ginkgo binary (required for test build and run)
 go install -v github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}

--- a/scripts/install_avalanchego_release.sh
+++ b/scripts/install_avalanchego_release.sh
@@ -6,14 +6,14 @@
 set -e
 
 # Load the versions
-TELEPORTER_PATH=$(
+ICM_CONTRACTS_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")"
   cd .. && pwd
 )
-source "$TELEPORTER_PATH"/scripts/versions.sh
+source "$ICM_CONTRACTS_PATH"/scripts/versions.sh
 
 # Load the constants
-source "$TELEPORTER_PATH"/scripts/constants.sh
+source "$ICM_CONTRACTS_PATH"/scripts/constants.sh
 
 ############################
 # download avalanchego

--- a/scripts/install_subnetevm_release.sh
+++ b/scripts/install_subnetevm_release.sh
@@ -6,12 +6,12 @@
 set -e
 
 # Load the versions
-TELEPORTER_PATH=$(
+ICM_CONTRACTS_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")"
   cd .. && pwd
 )
-source "$TELEPORTER_PATH"/scripts/versions.sh
-source "$TELEPORTER_PATH"/scripts/constants.sh
+source "$ICM_CONTRACTS_PATH"/scripts/versions.sh
+source "$ICM_CONTRACTS_PATH"/scripts/constants.sh
 
 ############################
 # download subnet-evm

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,29 +4,29 @@
 
 set -e
 
-TELEPORTER_PATH=$(
+ICM_CONTRACTS_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")"
   cd .. && pwd
 )
 
-source $TELEPORTER_PATH/scripts/versions.sh
+source $ICM_CONTRACTS_PATH/scripts/versions.sh
 
 function solFormat() {
     # format solidity contracts
     echo "Formatting Solidity contracts..."
-    forge fmt --root $TELEPORTER_PATH $TELEPORTER_PATH/contracts/**
+    forge fmt --root $ICM_CONTRACTS_PATH $ICM_CONTRACTS_PATH/contracts/**
 }
 
 function solFormatCheck() {
     # format solidity contracts
     echo "Checking formatting of Solidity contracts..."
-    forge fmt --check --root $TELEPORTER_PATH $TELEPORTER_PATH/contracts/**
+    forge fmt --check --root $ICM_CONTRACTS_PATH $ICM_CONTRACTS_PATH/contracts/**
 }
 
 function solLinter() {
     # lint solidity contracts
     echo "Linting Solidity contracts..."
-    cd $TELEPORTER_PATH
+    cd $ICM_CONTRACTS_PATH
     # "solhint **/*.sol" runs differently than "solhint '**/*.sol'", where the latter checks sol files
     # in subdirectories. The former only checks sol files in the current directory and directories one level down.
     solhint '**/*.sol' --config ./.solhint.json --ignore-path ./.solhintignore --max-warnings 0
@@ -37,8 +37,8 @@ function golangLinter() {
     go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
     echo "Linting Golang code..."
-    cd $TELEPORTER_PATH
-    golangci-lint run --config=$TELEPORTER_PATH/.golangci.yml ./...
+    cd $ICM_CONTRACTS_PATH
+    golangci-lint run --config=$ICM_CONTRACTS_PATH/.golangci.yml ./...
 }
 
 function runAll() {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -5,7 +5,7 @@
 set -e
 set -o pipefail
 
-TELEPORTER_PATH=$(
+ICM_CONTRACTS_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")"
   cd .. && pwd
 )
@@ -13,7 +13,7 @@ TELEPORTER_PATH=$(
 # Pass in the full name of the dependency.
 # Parses go.mod for a matching entry and extracts the version number.
 function getDepVersion() {
-    grep -m1 "^\s*$1" $TELEPORTER_PATH/go.mod | cut -d ' ' -f2
+    grep -m1 "^\s*$1" $ICM_CONTRACTS_PATH/go.mod | cut -d ' ' -f2
 }
 
 function extract_commit() {
@@ -44,5 +44,5 @@ SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-$(extract_commit "$(getDepVersion githu
 GOLANGCI_LINT_VERSION=${GOLANGCI_LINT_VERSION:-'v1.60'}
 
 # Extract the Solidity version from foundry.toml
-SOLIDITY_VERSION=$(awk -F"'" '/^solc_version/ {print $2}' $TELEPORTER_PATH/foundry.toml)
-EVM_VERSION=$(awk -F"'" '/^evm_version/ {print $2}' $TELEPORTER_PATH/foundry.toml)
+SOLIDITY_VERSION=$(awk -F"'" '/^solc_version/ {print $2}' $ICM_CONTRACTS_PATH/foundry.toml)
+EVM_VERSION=$(awk -F"'" '/^evm_version/ {print $2}' $ICM_CONTRACTS_PATH/foundry.toml)


### PR DESCRIPTION
## Why this should be merged
Rename bash variable from `TELEPORTER_PATH` to `ICM_CONTRACTS_PATH`